### PR TITLE
Feat: 뉴스 상세화면, 커뮤니티 상세화면 구분

### DIFF
--- a/kickon-fe/package.json
+++ b/kickon-fe/package.json
@@ -18,7 +18,7 @@
     "react-hook-form": "^7.54.2",
     "react-icons": "^5.5.0",
     "react-redux": "^9.2.0",
-    "react-router-dom": "^7.4.0",
+    "react-router-dom": "^7.4.1",
     "styled-components": "^6.1.16",
     "yup": "^1.6.1"
   },

--- a/kickon-fe/src/components/PostDetail/postDetail.jsx
+++ b/kickon-fe/src/components/PostDetail/postDetail.jsx
@@ -26,6 +26,7 @@ const PostDetail = () => {
     // const [isMenuOpen, setIsMenuOpen] = useState(false);
     const [activePage, setActivePage] = useState(1);
     const [likedComments, setLikedComments] = useState({});
+    const [isLiked, setIsLiked] = useState(false);
     // const menuRef = useRef(null);
 
     // const handleClickOutside = (e) => {
@@ -105,9 +106,10 @@ const PostDetail = () => {
             </ArticleContent>
 
             <ArticleActions>
-                <LikeButton>
+                <LikeButton isLiked={isLiked} onClick={() => setIsLiked(!isLiked)}>
                     <img src={BKickIcon} alt="킥 아이콘" width={14} height={14} />
-                    킥
+                    <span>킥</span>
+                    <span className="likes">{post.likes}</span>
                 </LikeButton>
             </ArticleActions>
 

--- a/kickon-fe/src/components/PostDetail/postDetail.jsx
+++ b/kickon-fe/src/components/PostDetail/postDetail.jsx
@@ -1,97 +1,109 @@
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useRef, useState} from 'react';
 import {
     ArticleContainer, ArticleHeader, ArticleTitle, ArticleInfo,
-    VerifiedIcon, ArticleMeta, ArticleContent, ArticleImage,
-    ArticleText, ArticleActions, LikeButton, TimeLabel, ViewLabel,
+    ArticleMeta, ArticleContent, ArticleImage, ArticleText,
+    ArticleActions, LikeButton, TimeLabel, ViewLabel,
     CommentInputBox, CommentInputLabel, CommentInput, SubmitButton,
     CommentsSection, CommentItem, CommentHeader, CommentContent,
-    CommentActions, CommentLikes, ReplyButton,
-    CommentInputContainer, CommentsSectionTitle, CommentHeaderWrapper, MoreButton
+    CommentActions, CommentLikes, ReplyButton, CommentInputContainer,
+    CommentsSectionTitle, CommentHeaderWrapper, MoreButton, ArticleLabel,
+    ArticleCategory, ArticleTeam
 } from './postDetail.style.js';
 import RKickIcon from "../../assets/good_red.svg"
 import BKickIcon from "../../assets/good_black.svg"
 import KickIcon from "../../assets/good.svg"
 import ProfileIcon from "../../assets/profile.svg"
 import { FaRegComment, FaCheckCircle } from "react-icons/fa";
-import { FiMoreHorizontal } from "react-icons/fi";
-import { MdExpandMore } from "react-icons/md";
+// import { FiMoreHorizontal } from "react-icons/fi";
+// import { MdExpandMore } from "react-icons/md";
 import Pagination from "../Pagination/pagination"
+import NewsImage from "../../assets/thumbnail.png"
+import {MdExpandMore} from "react-icons/md";
 
 
 const PostDetail = () => {
-    const [commentText, setCommentText] = useState('');
-    const [isMenuOpen, setIsMenuOpen] = useState(false);
+    // const [commentText, setCommentText] = useState('');
+    // const [isMenuOpen, setIsMenuOpen] = useState(false);
     const [activePage, setActivePage] = useState(1);
     const [likedComments, setLikedComments] = useState({});
-    const menuRef = useRef(null);
+    // const menuRef = useRef(null);
 
-    const handleClickOutside = (e) => {
-        if (menuRef.current && !menuRef.current.contains(e.target) && !e.target.closest('.more-button')) {
-            setIsMenuOpen(false);
-        }
+    // const handleClickOutside = (e) => {
+    //     if (menuRef.current && !menuRef.current.contains(e.target) && !e.target.closest('.more-button')) {
+    //         setIsMenuOpen(false);
+    //     }
+    // };
+
+    // useEffect(() => {
+    //     // 클릭했을 때 메뉴를 닫도록 이벤트 리스너 추가
+    //     document.addEventListener('click', handleClickOutside);
+    //
+    //     // 컴포넌트가 언마운트 될 때 이벤트 리스너 제거
+    //     return () => {
+    //         document.removeEventListener('click', handleClickOutside);
+    //     };
+    // }, []);
+
+
+    const post = {
+        title: "[충격] 쿠르투아는 시메오네를 향해 쏘아붙인다: \"저는 그런 피해자 의식에 지쳤어요. 늘 울기만 하거든요.\"",
+        user: {
+            nickname: "하늘천사랑",
+            profileImageUrl: ProfileIcon
+        },
+        team: {
+            "pk": 1,
+            "nameKr": "전남드래곤즈",
+            "nameEn": "Jeonnam Dragons",
+            "logoUrl": "https://media.api-sports.io/football/teams/40.png"
+        },
+        createdAt: "2025-04-03T15:11:07.010Z",
+        views: 120,
+        likes: 45,
+        replies: 3,
+        image: "https://premierskillsenglish.britishcouncil.org/sites/default/files/styles/main_large/public/learning/1850/image/gerrardcelebrates.jpg?itok=LQ1fKFIj",
+        content: "벨기에 선수가 혼합 구역에서 콜로 선수의 페널티 거부에 대한 항의에 응답하고 있다.\n\n티보 쿠르투아는 기자 회견에서 시메오네 가 화를 내자 혼합 구역에서 반응하며, 승부차기에서 훌리안 알바레즈 가 페널티킥을 두 번 터치하는 것을 기자가 봤는지 큰 소리로 물었다 . 벨기에인은 시메오네에 대해 엄하게 말했다. \"저는 그런 피해자 의식에 질렸어요. 항상 이런 일에 대해 울부짖어요. 심판은 스페인이나 유럽에서도 팀에 이로운 일을 하고 싶어하지 않아요. 그들은 그것을 분명히 보고 그렇게 말했어요. 그들은 인간이고, 기술을 통해 그것을 분명히 봤어요. 첫 번째 분에 1-0으로 이기고 두 번째 분에 가지 않는다면, 그것은 그들의 경기의 잘못이에요.\"앞서 Movistar 에서 그는 경기를 분석했습니다. \"결국 복권이었습니다. 더블인 것 같아서 심판에게 말했습니다. 보기 쉽지 않고 그들에게는 불운입니다. 그리고 코레아가 골을 넣지 못한 것은 저에게 불운이었습니다. 우리는 최고의 경기를 하지 못했지만, 통과했고, 그것이 중요합니다.\"\n\n그리고 그는 총격전을 어떻게 공부했는지 분석했습니다. \"우리는 이번 주에 무엇을 했는지에 대해 이야기했고, 그 다음에는 스트라이커에 따라 다릅니다... 소를로트는 슛을 할 때 항상 바뀌었습니다. 저는 그가 바뀔 것이라고 생각했습니다. 훌리안의 경우, 저는 의심했습니다. 그가 중앙에서 슛을 할 것이라고 생각하지 않았습니다. 우리는 요렌테에 대한 정보가 없었지만, 훈련에서 그는 오른쪽으로 슛하는 것을 좋아했고, 그는 멀리 떨어진 슛을 쳤습니다.\"",
+        comments: Array(15).fill().map((_, index) => ({
+            id: index,
+            user: {
+                nickname: '닉네임',
+                profileImageUrl: ProfileIcon
+            },
+            createdAt: '2025-01-20T10:42:00.000Z',
+            content: index % 5 === 2 ? '잘보고 가요! 손흥민 선수 응원합니다!' : '서울은 전북 노인네들만 영입하냐',
+            likes: index % 2 === 0 ? 3 : index % 3 === 0 ? 2 : 1,
+            isLiked: false
+        }))
     };
 
-    useEffect(() => {
-        // 클릭했을 때 메뉴를 닫도록 이벤트 리스너 추가
-        document.addEventListener('click', handleClickOutside);
-
-        // 컴포넌트가 언마운트 될 때 이벤트 리스너 제거
-        return () => {
-            document.removeEventListener('click', handleClickOutside);
-        };
-    }, []);
-
-    const toggleLike = (commentId) => {
-        setLikedComments((prev) => ({
-            ...prev,
-            [commentId]: !prev[commentId], // 클릭한 댓글만 토글
-        }));
-    };
-
-    // 댓글 데이터
-    const comments = Array(15).fill().map((_, index) => ({
-        id: index,
-        author: '닉네임',
-        date: '2025.01.20 10:42',
-        content: index % 5 === 2 ? '잘보고 가요! 손흥민 선수 응원합니다!' : '서울은 전북 노인네들만 영입하냐',
-        likes: index % 2 === 0 ? 3 : index % 3 === 0 ? 2 : 1,
-        isLiked: false
-    }));
 
     return (
         <ArticleContainer>
+            {location.pathname === "/news/detail" && <ArticleImage src={post.image} />}
+            {location.pathname === "/news/detail" &&
+                <ArticleLabel>
+                    <ArticleTeam src={post.team.logoUrl}/>
+                    <ArticleCategory>부상</ArticleCategory>
+                </ArticleLabel>}
             <ArticleHeader>
-                <ArticleTitle>(속보) 손흥민 부상 ㄷㄷ</ArticleTitle>
+                <ArticleTitle>{post.title}</ArticleTitle>
                 <ArticleInfo>
-                    <img src={ProfileIcon} alt="프로필 아이콘" width={24} height={24} />
-                    닉네임
-                    <FaCheckCircle/>
-                    <TimeLabel>1시간 전</TimeLabel> | <ViewLabel>읽음 1,204</ViewLabel>
+                    <img src={post.user.profileImageUrl || ProfileIcon} alt="프로필 아이콘" width={24} height={24} />
+                    {post.user.nickname}
+                    <FaCheckCircle />
+                    <TimeLabel>{new Date(post.createdAt).toLocaleString()}</TimeLabel> | <ViewLabel>읽음 {post.views}</ViewLabel>
                     <ArticleMeta>
-                        <img src={KickIcon} alt="좋아요수 아이콘" width={10} height={10} />56
-                        <FaRegComment alt="댓글수 아이콘" />20
+                        <img src={KickIcon} alt="좋아요수 아이콘" width={10} height={10} /> {post.likes}
+                        <FaRegComment alt="댓글수 아이콘" /> {post.replies}
                     </ArticleMeta>
-                    <FiMoreHorizontal
-                        className="more-button"
-                        onClick={() => {
-                            console.log("Button clicked"); // 클릭 확인용 로그
-                            setIsMenuOpen(!isMenuOpen);
-                        }}
-                        alt="더보기 아이콘"
-                    />
                 </ArticleInfo>
             </ArticleHeader>
 
-            {/* 게시글 내용 */}
             <ArticleContent>
-                <ArticleImage src="/api/placeholder/400/250" alt="경기장 이미지" />
-                <ArticleText>
-                    전북현대(이하 전북)가 국가대표 출신 측면 윙어 문선민과 작별했다.
-
-                </ArticleText>
+                {location.pathname !== "/news/detail" && <ArticleImage src={post.image} />}
+                <ArticleText>{post.content}</ArticleText>
             </ArticleContent>
 
-            {/* 게시글 액션 */}
             <ArticleActions>
                 <LikeButton>
                     <img src={BKickIcon} alt="킥 아이콘" width={14} height={14} />
@@ -102,49 +114,35 @@ const PostDetail = () => {
             <CommentInputBox>
                 <CommentInputLabel>댓글 쓰기</CommentInputLabel>
                 <CommentInputContainer>
-                    <CommentInput
-                        placeholder="댓글을 입력하세요..."
-                        value={commentText}
-                        onChange={(e) => setCommentText(e.target.value)}
-                    />
+                    <CommentInput placeholder="댓글을 입력하세요..." />
                     <SubmitButton>등록</SubmitButton>
                 </CommentInputContainer>
             </CommentInputBox>
 
-            {/* 댓글 섹션 */}
             <CommentsSection>
-                <CommentsSectionTitle>댓글 14개</CommentsSectionTitle>
-                {comments.map((comment, index) => (
-                    <CommentItem key={index}>
+                <CommentsSectionTitle>댓글 {post.replies}개</CommentsSectionTitle>
+                {post.comments && post.comments.map((comment) => (
+                    <CommentItem key={comment.id}>
                         <CommentHeaderWrapper>
                             <CommentHeader>
-                                <img src={ProfileIcon} alt="프로필 아이콘" width={24} height={24} />
-                                <span style={{ fontSize: '0.75rem', marginRight: '0.3rem', color: '#000' }}>닉네임</span>
-                                <span style={{ fontSize: '0.7rem', color: '#888' }}>{comment.date}</span>
+                                <img src={comment.user.profileImageUrl || ProfileIcon} alt="프로필 아이콘" width={24} height={24} />
+                                <span style={{ fontSize: '0.75rem', marginRight: '0.3rem', color: '#000' }}>{comment.user.nickname}</span>
+                                <span style={{ fontSize: '0.7rem', color: '#888' }}>{new Date(comment.createdAt).toLocaleString()}</span>
                             </CommentHeader>
                             <CommentLikes
                                 key={comment.id}
-                                active={likedComments[comment.id] || false} // 개별적으로 관리
-                                onClick={() => toggleLike(comment.id)}
+                                active={likedComments[comment.id] || false}
+                                onClick={() => setLikedComments(prev => ({ ...prev, [comment.id]: !prev[comment.id] }))}
                             >
-                                <img
-                                    src={likedComments[comment.id] ? RKickIcon : KickIcon} // 개별 상태 반영
-                                    alt="좋아요 아이콘"
-                                    width={12}
-                                    height={12}
-                                    style={{ cursor: "pointer" }}
-                                />
+                                <img src={likedComments[comment.id] ? RKickIcon : KickIcon} alt="좋아요 아이콘" width={12} height={12} />
                                 {comment.likes}
                             </CommentLikes>
                         </CommentHeaderWrapper>
-                        <CommentContent>
-                            {comment.content}
-                        </CommentContent>
+                        <CommentContent>{comment.content}</CommentContent>
                         <CommentActions>
-                            <ReplyButton>답글</ReplyButton>
-                            {index % 4 === 0 && (
-                                <MoreButton> <MdExpandMore width={20} height={20}/>  답글 2개</MoreButton>
-                            )}
+                            {location.pathname === "/community/detail" && <ReplyButton>답글</ReplyButton>}
+                            <MoreButton> <MdExpandMore width={20} height={20}/>  답글 2개</MoreButton>
+
                         </CommentActions>
                     </CommentItem>
                 ))}

--- a/kickon-fe/src/components/PostDetail/postDetail.jsx
+++ b/kickon-fe/src/components/PostDetail/postDetail.jsx
@@ -58,6 +58,7 @@ const PostDetail = () => {
             "nameEn": "Jeonnam Dragons",
             "logoUrl": "https://media.api-sports.io/football/teams/40.png"
         },
+        badge: "부상",
         createdAt: "2025-04-03T15:11:07.010Z",
         views: 120,
         likes: 45,
@@ -84,7 +85,7 @@ const PostDetail = () => {
             {location.pathname === "/news/detail" &&
                 <ArticleLabel>
                     <ArticleTeam src={post.team.logoUrl}/>
-                    <ArticleCategory>부상</ArticleCategory>
+                    <ArticleCategory>{post.badge}</ArticleCategory>
                 </ArticleLabel>}
             <ArticleHeader>
                 <ArticleTitle>{post.title}</ArticleTitle>

--- a/kickon-fe/src/components/PostDetail/postDetail.style.js
+++ b/kickon-fe/src/components/PostDetail/postDetail.style.js
@@ -108,20 +108,25 @@ export const ArticleActions = styled.div`
 
 export const LikeButton = styled.button`
     display: flex;
-    width: 4.308rem;
     height: 1.68rem;
     padding: 0.125rem 0.75rem;
     justify-content: center;
     align-items: center;
-    gap: 0.625rem;
+    gap: 0.4rem;
     flex-shrink: 0;
     border: none;
     border-radius: 0.5rem;
-    background: rgba(192, 12, 11, 0.90);
-    /* Button/킥_레드_20% */
-    box-shadow: 0px 2px 10px 0px rgba(217, 25, 32, 0.20);
-    font-size: 0.7rem;
-    color: white;
+    background: ${({ isLiked }) => (isLiked ? 'rgba(192, 12, 11, 0.90)' : 'white')};
+    box-shadow: ${({ isLiked }) => (isLiked ? '0px 2px 10px 0px rgba(217, 25, 32, 0.20)' : '0px 2px 10px 0px rgba(0, 0, 0, 0.20)')};
+    font-size: 0.65rem;
+    color: ${({ isLiked }) => (isLiked ? 'white' : 'black')};
+    cursor: pointer;
+
+
+
+    &:hover .likes {
+        color: ${({ isLiked }) => (isLiked ? 'white' : 'var(--Primary-primary_900, #C00C0B)')};
+    }
 
     & svg {
         margin-right: 6px;
@@ -253,7 +258,7 @@ export const CommentHeader = styled.div`
     display: flex;
     align-items: center;
     gap: 6px;
-    margin-bottom: 6px;
+    margin-bottom: 0.1rem;
 `;
 export const CommentLikes = styled.button`
     display: flex;

--- a/kickon-fe/src/components/PostDetail/postDetail.style.js
+++ b/kickon-fe/src/components/PostDetail/postDetail.style.js
@@ -11,6 +11,40 @@ export const ArticleContainer = styled.div`
     position: relative;
 `;
 
+export const ArticleLabel = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 2.37rem;
+    margin-left: 1.3rem;
+`
+export const ArticleTeam = styled.img`
+    display: flex;    
+    width: 0.6rem;
+    justify-content: center;
+    align-items: center;
+`
+export const ArticleCategory = styled.div`
+    display: flex;
+    width: 1.83rem;
+    height: 1.07rem;
+    padding: 0.125rem 0.625rem;
+    justify-content: center;
+    align-items: center;
+    gap: 0.625rem;
+    
+    border-radius: 1.25rem;
+    background: var(--Black-black_900, #000);
+
+    color: var(--sub1, #FFF);
+    /* Caption/cap1_Pre_m_12px */
+    font-family: Pretendard;
+    font-size: 0.53rem;
+    font-style: normal;
+    font-weight: 500;
+    line-height: normal;
+`
+
 export const ArticleHeader = styled.div`
     display: flex;
     flex-direction: column;
@@ -33,14 +67,6 @@ export const ArticleInfo = styled.div`
     color: #666;
 `;
 
-export const VerifiedIcon = styled.span`
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    color: #1da1f2;
-    margin-left: 2px;
-`;
-
 export const ArticleMeta = styled.div`
     margin-left: auto;
     display: flex;
@@ -54,14 +80,19 @@ export const ArticleContent = styled.div`
 `;
 
 export const ArticleImage = styled.img`
-    width: 100%;
-    max-height: 300px;
-    object-fit: cover;
+    width: 28.5rem;
+    height: 14.14rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    align-self: stretch;
+    border-radius: 0.625rem;
+    margin: 0.7rem;
 `;
 
 export const ArticleText = styled.p`
-    padding: 16px;
-    margin: 0;
+    margin: 0.7rem;
+    margin-bottom: 5.38rem;
     font-size: 0.718rem;
     line-height: 1.6;
     color: #333;

--- a/kickon-fe/src/components/PostDetail/postDetail.style.js
+++ b/kickon-fe/src/components/PostDetail/postDetail.style.js
@@ -26,7 +26,6 @@ export const ArticleTeam = styled.img`
 `
 export const ArticleCategory = styled.div`
     display: flex;
-    width: 1.83rem;
     height: 1.07rem;
     padding: 0.125rem 0.625rem;
     justify-content: center;

--- a/kickon-fe/yarn.lock
+++ b/kickon-fe/yarn.lock
@@ -1198,17 +1198,17 @@ react-redux@^9.2.0:
     "@types/use-sync-external-store" "^0.0.6"
     use-sync-external-store "^1.4.0"
 
-react-router-dom@^7.4.0:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-7.4.0.tgz#cb97968f4233c0bec57c9662442a7c070b4c31e9"
-  integrity sha512-VlksBPf3n2bijPvnA7nkTsXxMAKOj+bWp4R9c3i+bnwlSOFAGOkJkKhzy/OsRkWaBMICqcAl1JDzh9ZSOze9CA==
+react-router-dom@^7.4.1:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-7.4.1.tgz#fd913abb488364859c343881ecb7b7bc84b902f2"
+  integrity sha512-L3/4tig0Lvs6m6THK0HRV4eHUdpx0dlJasgCxXKnavwhh4tKYgpuZk75HRYNoRKDyDWi9QgzGXsQ1oQSBlWpAA==
   dependencies:
-    react-router "7.4.0"
+    react-router "7.4.1"
 
-react-router@7.4.0:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-7.4.0.tgz#9787041425bc4bf52e6d472b6ccfd78a43ace133"
-  integrity sha512-Y2g5ObjkvX3VFeVt+0CIPuYd9PpgqCslG7ASSIdN73LwA1nNWzcMLaoMRJfP3prZFI92svxFwbn7XkLJ+UPQ6A==
+react-router@7.4.1:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-7.4.1.tgz#0e6af1eefb8370d2cd79c961b87708afdb50fe64"
+  integrity sha512-Vmizn9ZNzxfh3cumddqv3kLOKvc7AskUT0dC1prTabhiEi0U4A33LmkDOJ79tXaeSqCqMBXBU/ySX88W85+EUg==
   dependencies:
     "@types/cookie" "^0.6.0"
     cookie "^1.0.1"


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #25

## ✨ 작업 개요
> 상세화면 컴포넌트를 경로에 따라 다른 구성을 보이게 수정하였다

-뉴스화면
<img width="499" alt="스크린샷 2025-04-04 오후 2 50 01" src="https://github.com/user-attachments/assets/218c2b8f-dc83-4940-86e3-bf5dc4f3e458" />

-커뮤니티화면
<img width="491" alt="스크린샷 2025-04-04 오후 2 50 39" src="https://github.com/user-attachments/assets/58b6c55c-b1a7-48b7-9bf3-b4ec99553303" />


## 🧐 집중 리뷰 요청
> 아직 뉴스에선 우리팀, 상대팀 구분하지 않았으며 경로 구분은 했지만 답글과 같은 디테일 등은 주말까지 완료할 예정입니다.