### PR TITLE
Refactor: 승부예측 컴포넌트 UI 개선

### DIFF
--- a/kickon-fe/src/components/MatchCard/matchCard.jsx
+++ b/kickon-fe/src/components/MatchCard/matchCard.jsx
@@ -13,7 +13,18 @@ import {
     CountButton,
     CountDisplay,
     ConfirmButton,
-    JoinedText, TimeTitle, RightText
+    JoinedText,
+    TimeTitle,
+    RightText,
+    TeamName,
+    TeamLogo,
+    ParticipationPercentage,
+    TeamContainer,
+    TeamLeftContainer,
+    TeamCenterContainer,
+    TeamRightContainer,
+    TeamNameContainer,
+    TeamRightNameContainer
 } from "./matchCard.style.js";
 import chevronUp from "../../assets/chevron_up.svg";
 import chevronDown from "../../assets/chevron_down.svg";
@@ -30,52 +41,220 @@ const MatchCard = () => {
 
     const incrementCount = (event, index) => {
         event.stopPropagation(); // MatchButton 클릭 방지
-        setCounts((prev) => ({ ...prev, [index]: prev[index] + 1 }));
+
+        // 무승부 선택 시 양 팀 카운트 동시에 증가
+        if (selected === 1) {
+            setCounts((prev) => ({
+                ...prev,
+                0: prev[0] + 1,
+                2: prev[2] + 1
+            }));
+        } else {
+            setCounts((prev) => ({ ...prev, [index]: prev[index] + 1 }));
+        }
     };
 
     const decrementCount = (event, index) => {
         event.stopPropagation(); // MatchButton 클릭 방지
-        setCounts((prev) => ({ ...prev, [index]: Math.max(0, prev[index] - 1) }));
+
+        // 무승부 선택 시 양 팀 카운트 동시에 감소
+        if (selected === 1) {
+            setCounts((prev) => ({
+                ...prev,
+                0: Math.max(0, prev[0] - 1),
+                2: Math.max(0, prev[2] - 1)
+            }));
+        } else {
+            setCounts((prev) => ({ ...prev, [index]: Math.max(0, prev[index] - 1) }));
+        }
     };
 
     const handleConfirm = () => {
         setIsConfirmed(true);
     };
 
+    const formatKoreanDate = (dateString) => {
+        const date = new Date(dateString);
+
+        const month = String(date.getMonth() + 1).padStart(2, "0");
+        const day = String(date.getDate()).padStart(2, "0");
+
+        const daysKor = ["일", "월", "화", "수", "목", "금", "토"];
+        const dayOfWeek = daysKor[date.getDay()];
+
+        const hour = String(date.getHours()).padStart(2, "0");
+        const minute = String(date.getMinutes()).padStart(2, "0");
+
+        return `${month}.${day} (${dayOfWeek}) ${hour}:${minute}`;
+    };
+
+    const data = {
+        name: "K리그 1",
+        games : {
+            homeTeam : {
+                "name" : "FC 서울",
+                "logoUrl" : "https://media.api-sports.io/football/teams/45.png"
+            },
+            awayTeam : {
+                "name" : "수원 FC",
+                "logoUrl" : "https://media.api-sports.io/football/teams/42.png"
+            },
+            gameStatus: "예측 진행중",
+            startAt: "2025-04-05T11:30:00",
+            gambleResult: {
+                home: 600,
+                away: 500,
+                draw: 104,
+                participationNumber: 1204
+            }
+        }
+    };
+
+    // Calculate percentages for each option
+    const calculatePercentage = (value) => {
+        const total = data.games.gambleResult.home +
+            data.games.gambleResult.draw +
+            data.games.gambleResult.away;
+        return ((value / total) * 100).toFixed(1);
+    };
+
+    const homePercentage = calculatePercentage(data.games.gambleResult.home);
+    const drawPercentage = calculatePercentage(data.games.gambleResult.draw);
+    const awayPercentage = calculatePercentage(data.games.gambleResult.away);
+
+    // 항상 카운트 컨트롤이 보이도록 설정 (selected가 null이 아닐 때)
+    const showCountControls = selected !== null;
+
+    // CountDisplay의 배경색 결정 로직
+    const getCountDisplayColor = (index) => {
+        // 0점이면 회색
+        if (counts[index] === 0) {
+            return "#AFAFAF";
+        }
+
+        // 두 팀 점수가 같으면서 0이 아니면 둘 다 빨간색
+        if (counts[0] === counts[2] && counts[0] > 0) {
+            return "#C00C0B";
+        }
+
+        // 점수가 높은 팀만 빨간색
+        const maxCount = Math.max(counts[0], counts[2]);
+        return counts[index] === maxCount ? "#C00C0B" : "#AFAFAF";
+    };
+
     return (
         <MatchCardContainer>
             <StyledTopContainer>
-                <LeftText>K리그 1</LeftText>
+                <LeftText>{data.name}</LeftText>
                 <RightBadge>{isConfirmed ? "참여 완료" : "예측 진행 중"}</RightBadge>
             </StyledTopContainer>
             <RightText>마감 50분전</RightText>
             <TimeGuide>
                 <TimeTitle>경기 전</TimeTitle>
-                <TimeText>01.25 (토) 04:30</TimeText>
+                <TimeText>{formatKoreanDate(data.games.startAt)}</TimeText>
             </TimeGuide>
             <MatchButtonContainer>
-                {["FC 서울", "무승부", "수원 FC"].map((option, index) => (
+                {[
+                    {
+                        name: data.games.homeTeam.name,
+                        logo: data.games.homeTeam.logoUrl,
+                        percentage: homePercentage,
+                        value: data.games.gambleResult.home
+                    },
+                    {
+                        name: "무승부",
+                        logo: null,
+                        percentage: drawPercentage,
+                        value: data.games.gambleResult.draw
+                    },
+                    {
+                        name: data.games.awayTeam.name,
+                        logo: data.games.awayTeam.logoUrl,
+                        percentage: awayPercentage,
+                        value: data.games.gambleResult.away
+                    }
+                ].map((option, index) => (
                     <MatchButton
                         key={index}
                         aria-selected={selected === index}
                         onClick={() => handleClick(index)}
-                        style={{
-                            position: "relative",
-                            pointerEvents: isConfirmed ? "none" : "auto" // ❌ 선택 완료 후 클릭 방지
-                        }}
+                        disabled={isConfirmed}
                     >
-                        {option}
+                        {/* 왼쪽 팀 (index === 0) */}
+                        {index === 0 && (
+                            <TeamLeftContainer>
+                                {option.logo && (
+                                    <TeamLogo
+                                        src={option.logo}
+                                        alt={option.name}
+                                        small={selected !== null || isConfirmed}
+                                    />
+                                )}
+                                <TeamNameContainer>
+                                    <TeamName small={selected !== null || isConfirmed}>
+                                        {option.name}
+                                    </TeamName>
+                                    {(selected !== null || isConfirmed) && (
+                                        <ParticipationPercentage>
+                                            {option.percentage}%
+                                        </ParticipationPercentage>
+                                    )}
+                                </TeamNameContainer>
+                            </TeamLeftContainer>
+                        )}
+
+                        {/* 중앙 (무승부) */}
+                        {index === 1 && (
+                            <TeamCenterContainer>
+                                <TeamName small={selected !== null || isConfirmed}>
+                                    {option.name}
+                                </TeamName>
+                                {(selected !== null || isConfirmed) && (
+                                    <ParticipationPercentage>
+                                        {option.percentage}%
+                                    </ParticipationPercentage>
+                                )}
+                            </TeamCenterContainer>
+                        )}
+
+                        {/* 오른쪽 팀 (index === 2) */}
+                        {index === 2 && (
+                            <TeamRightContainer>
+                                <TeamRightNameContainer>
+                                    <TeamName small={selected !== null || isConfirmed}>
+                                        {option.name}
+                                    </TeamName>
+                                    {(selected !== null || isConfirmed) && (
+                                        <ParticipationPercentage>
+                                            {option.percentage}%
+                                        </ParticipationPercentage>
+                                    )}
+                                </TeamRightNameContainer>
+                                {option.logo && (
+                                    <TeamLogo
+                                        src={option.logo}
+                                        alt={option.name}
+                                        small={selected !== null || isConfirmed}
+                                    />
+                                )}
+                            </TeamRightContainer>
+                        )}
+
+                        {/* 카운트 표시 및 컨트롤 버튼 */}
                         {(index === 0 || index === 2) && (
                             <CountDisplay
-                                isVisible={selected !== null} // ✅ 선택하면 항상 보이도록
+                                isVisible={(showCountControls && !isConfirmed) || isConfirmed}
                                 isLeft={index === 2}
                                 isZero={counts[index] === 0}
+                                style={{
+                                    backgroundColor: getCountDisplayColor(index)
+                                }}
                             >
                                 {counts[index]}
                             </CountDisplay>
                         )}
-                        {index === 0 && !isConfirmed && ( // ❌ 참여 완료 후 CountButton 숨김
-                            <ExtraContentRight isVisible={selected === index}>
+                        {index === 0 && !isConfirmed && (
+                            <ExtraContentRight isVisible={showCountControls}>
                                 <CountButton onClick={(e) => incrementCount(e, index)}>
                                     <img src={chevronUp} alt="Increase" />
                                 </CountButton>
@@ -87,8 +266,8 @@ const MatchCard = () => {
                                 </CountButton>
                             </ExtraContentRight>
                         )}
-                        {index === 2 && !isConfirmed && ( // ❌ 참여 완료 후 CountButton 숨김
-                            <ExtraContentLeft isVisible={selected === index}>
+                        {index === 2 && !isConfirmed && (
+                            <ExtraContentLeft isVisible={showCountControls}>
                                 <CountButton onClick={(e) => incrementCount(e, index)}>
                                     <img src={chevronUp} alt="Increase" />
                                 </CountButton>
@@ -104,11 +283,17 @@ const MatchCard = () => {
                 ))}
             </MatchButtonContainer>
 
-            {/* ✅ 선택한 버튼이 있고, 선택 완료 후에는 숨기기 */}
             {selected !== null && !isConfirmed && (
-                <ConfirmButton onClick={handleConfirm}>선택 완료</ConfirmButton>
+                <ConfirmButton
+                    onClick={handleConfirm}
+                    disabled={
+                        (selected === 1) && (counts[0] !== counts[2]) ||
+                        (selected === 0) && (counts[0] <= counts[2]) ||
+                        (selected === 2) && (counts[0] >= counts[2])
+                    }
+                >선택 완료</ConfirmButton>
             )}
-            <JoinedText>1,204명 참여</JoinedText>
+            <JoinedText>{data.games.gambleResult.participationNumber}명 참여</JoinedText>
         </MatchCardContainer>
     );
 };

--- a/kickon-fe/src/components/MatchCard/matchCard.style.js
+++ b/kickon-fe/src/components/MatchCard/matchCard.style.js
@@ -41,7 +41,7 @@ export const RightBadge = styled.div`
     background: #000;
     color: white;
     font-size: 0.54rem;
-    font-weight: 600;
+    font-weight: 350;
 `;
 
 export const RightText = styled.span`
@@ -148,7 +148,7 @@ export const MatchButton = styled.button`
         background: rgba(192, 12, 11, 0.30);
         box-shadow: 0px 1.44px 7.2px 0px rgba(217, 25, 32, 0.40);
     }
-
+    
     &:first-child {
         border-radius: 0.4rem 0rem 0rem 0.4rem;
     }

--- a/kickon-fe/src/components/MatchCard/matchCard.style.js
+++ b/kickon-fe/src/components/MatchCard/matchCard.style.js
@@ -127,6 +127,13 @@ export const MatchButton = styled.button`
     cursor: pointer;
     transition: all 0.3s ease;
     position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.2rem;
+    padding: 0.2rem;
+    pointer-events: ${props => props.disabled ? 'none' : 'auto'};
 
     &:not(:last-child) {
         border-right: 1px solid #F0F0F0;
@@ -153,6 +160,63 @@ export const MatchButton = styled.button`
     &:not(:first-child):not(:last-child) {
         border-radius: 0;
     }
+`;
+
+export const TeamContainer = styled.div`
+    display: flex;
+    width: 100%;
+    align-items: center;
+`;
+
+export const TeamLeftContainer = styled(TeamContainer)`
+    justify-content: flex-start;
+    margin-left: 0.71rem;
+`;
+
+export const TeamCenterContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+`;
+
+export const TeamRightContainer = styled(TeamContainer)`
+    justify-content: flex-end;
+    margin-right: 0.71rem;
+`;
+
+export const TeamNameContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    margin-left: 0.36rem;
+`;
+
+export const TeamRightNameContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    margin-right: 0.36rem;
+`;
+
+export const TeamLogo = styled.img`
+    width: 0.98rem;
+    height: 0.98rem;
+    object-fit: contain;
+    margin-bottom: 0.1rem;
+`;
+
+export const TeamName = styled.span`
+    font-size: ${props => props.small ? '0.62rem' : '0.673rem'};
+    font-weight: 500;
+    font-family: Pretendard;
+    text-align: center;
+`;
+
+export const ParticipationPercentage = styled.span`
+    font-size: 0.449rem;
+    font-weight: 400;
+    font-family: Pretendard;
 `;
 
 export const ExtraContentRight = styled.div`


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #이슈번호

## ✨ 작업 개요
> 
- 팀 로고 및 퍼센트 등 UI 개선
- 선택 팀의 점수가 높아야지만 참여완료 버튼이 눌리는 등 동작제한 추가
- 데이터 관리를 용이하게함

## 📷 이미지 첨부 (선택)
- 선택 전
![image](https://github.com/user-attachments/assets/c8695f21-70a8-45bd-b0d7-b84c204c5205)
- 선택 중
![image](https://github.com/user-attachments/assets/2d4470a1-7a21-452d-a151-8990bfdfce47)
- 선택 완료
![image](https://github.com/user-attachments/assets/b945ad64-691e-486a-96af-cd5f8bca0758)

