### PR TITLE
Refactor: rankingTable, header 디자인 수정

### DIFF
--- a/kickon-fe/src/components/Header/header.jsx
+++ b/kickon-fe/src/components/Header/header.jsx
@@ -1,48 +1,44 @@
 import React from "react";
-import {Link, useLocation} from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import * as S from "./header.style";
 import DarkLogoImage from "../../assets/logo_black.svg"; // 로고 이미지 경로
 import LogoImage from "../../assets/logo_white.svg";
 
-const Header = ({isDark}) => {
-    const location = useLocation();
-    const currentPath = location.pathname;
+const Header = ({ isDark }) => {
+  const location = useLocation();
+  const currentPath = location.pathname;
 
-    return (
-        <S.HeaderWrapper isDark={isDark}>
-            <S.Logo>
-                <Link to="/">
-                    <img src={isDark ? LogoImage : DarkLogoImage} alt="Logo" />
-                </Link>
-            </S.Logo>
+  return (
+    <S.HeaderWrapper isDark={isDark}>
+      <S.Logo>
+        <Link to="/">
+          <img src={isDark ? LogoImage : DarkLogoImage} alt="Logo" />
+        </Link>
+      </S.Logo>
 
-            <S.NavItem
-                to="/news"
-                isDark={isDark}
-                currentPath={currentPath}
-                itemPath="/news"
-            >
-                뉴스
-            </S.NavItem>
+      <S.NavItem
+        to="/news"
+        isDark={isDark}
+        currentPath={currentPath}
+        itemPath="/news"
+      >
+        뉴스
+      </S.NavItem>
 
-            <S.NavItem
-                to="/community"
-                isDark={isDark}
-                currentPath={currentPath}
-                itemPath="/community"
-            >
-                클럽 커뮤니티
-            </S.NavItem>
+      <S.NavItem
+        to="/community"
+        isDark={isDark}
+        currentPath={currentPath}
+        itemPath="/community"
+      >
+        클럽 커뮤니티
+      </S.NavItem>
 
-            <S.LoginButton
-                to="/login"
-                currentPath={currentPath}
-            >
-                로그인
-            </S.LoginButton>
-        </S.HeaderWrapper>
-    );
+      <S.LoginButton to="/login" currentPath={currentPath}>
+        로그인
+      </S.LoginButton>
+    </S.HeaderWrapper>
+  );
 };
-
 
 export default Header;

--- a/kickon-fe/src/components/Header/header.jsx
+++ b/kickon-fe/src/components/Header/header.jsx
@@ -1,31 +1,48 @@
 import React from "react";
-import { Link } from "react-router-dom";
-import {
-    HeaderWrapper,
-    Logo,
-    NavMenu,
-    NavItem,
-} from "./header.style";
+import {Link, useLocation} from "react-router-dom";
+import * as S from "./header.style";
 import DarkLogoImage from "../../assets/logo_black.svg"; // 로고 이미지 경로
 import LogoImage from "../../assets/logo_white.svg";
 
 const Header = ({isDark}) => {
+    const location = useLocation();
+    const currentPath = location.pathname;
+
     return (
-        <HeaderWrapper isDark={isDark}>
-            {/* 로고 */}
-            <Logo>
+        <S.HeaderWrapper isDark={isDark}>
+            <S.Logo>
                 <Link to="/">
                     <img src={isDark ? LogoImage : DarkLogoImage} alt="Logo" />
                 </Link>
-            </Logo>
+            </S.Logo>
 
-            {/* 네비게이션 메뉴 */}
-            <NavMenu>
-                <NavItem to="/news" isDark={isDark}>뉴스</NavItem>
-                <NavItem to="/community" isDark={isDark}>클럽 커뮤니티</NavItem>
-            </NavMenu>
-        </HeaderWrapper>
+            <S.NavItem
+                to="/news"
+                isDark={isDark}
+                currentPath={currentPath}
+                itemPath="/news"
+            >
+                뉴스
+            </S.NavItem>
+
+            <S.NavItem
+                to="/community"
+                isDark={isDark}
+                currentPath={currentPath}
+                itemPath="/community"
+            >
+                클럽 커뮤니티
+            </S.NavItem>
+
+            <S.LoginButton
+                to="/login"
+                currentPath={currentPath}
+            >
+                로그인
+            </S.LoginButton>
+        </S.HeaderWrapper>
     );
 };
+
 
 export default Header;

--- a/kickon-fe/src/components/Header/header.style.js
+++ b/kickon-fe/src/components/Header/header.style.js
@@ -3,30 +3,67 @@ import { Link } from "react-router-dom";
 
 export const HeaderWrapper = styled.header`
     display: flex;
+    height: 3.15rem;
     align-items: center;
     background-color: ${(props) => (props.isDark ? "#363636" : "#fff")};
-    padding: 0.4rem 10rem; /* 좌우 여백 */
-    border-bottom: 0.1rem solid #ddd; /* 하단 경계선 */
+    flex-shrink: 0;
 `;
 
 export const Logo = styled.div`
-    /* 로고가 왼쪽에 위치하도록 설정 */
-    margin-right: 4rem; /* 로고와 첫 번째 NavItem 사이 간격 */
+    margin: 0 4rem 0 12.25rem;
 
     a img {
-        height: 2.5rem; /* 로고 이미지 높이 */
+        height: 2.1rem; /* 로고 이미지 높이 */
         width: auto;
     }
 `;
 
-export const NavMenu = styled.nav`
-    display: flex;
+export const NavItem = styled(Link)`
+    margin-left: 4rem;
+    font-size: 0.85rem;
+    font-weight: 400;
+    text-decoration: none;
+    color: ${(props) => {
+    const { currentPath, itemPath } = props;
+
+    // Case 1: Home - both #000
+    if (currentPath === "/") return "#000";
+
+    // Case 2: News - News #FFF, Club Community #8F8F8F
+    if (currentPath.includes("/news")) {
+        return itemPath === "/news" ? "#FFF" : "#8F8F8F";
+    }
+
+    // Case 3: Club Community #FFF, News #8F8F8F
+    if (currentPath.includes("/community")) {
+        return itemPath === "/community" ? "#FFF" : "#8F8F8F";
+    }
+
+    // Case 4: Signup - same as profile settings (both #FFF)
+    if (currentPath === "/signup") return "#FFF";
+
+    // Default (fallback) using isDark prop
+    return props.isDark ? "#FFF" : "#000";
+}};
 `;
 
-export const NavItem = styled(Link)`
-    margin-left: 4rem; /* 네비게이션 아이템 간 간격 */
-    font-size: 0.85rem;
-    font-weight: 600;
-    text-decoration: none; /* 밑줄 제거 */
-    color: ${(props) => (props.isDark ? "#FFFFFF" : "#222")};
+export const LoginButton = styled(Link)`
+    display: ${(props) => (props.currentPath === "/signup" ? "flex" : "none")};
+    position: absolute;
+    right: 12.5rem;
+    height: 1.7rem;
+    padding: 0.4375rem 0.7875rem;
+    justify-content: center;
+    align-items: center;
+    gap: 0.4375rem;
+    border-radius: 0.875rem;
+    border: 1px solid #DCDCDC;
+    background: #FFF;
+    color: #C00C0B;
+    text-align: right;
+    font-size: 0.7875rem;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 1rem; /* 133.333% */
+    text-decoration: none;
 `;

--- a/kickon-fe/src/components/Header/header.style.js
+++ b/kickon-fe/src/components/Header/header.style.js
@@ -2,28 +2,28 @@ import styled from "styled-components";
 import { Link } from "react-router-dom";
 
 export const HeaderWrapper = styled.header`
-    display: flex;
-    height: 3.15rem;
-    align-items: center;
-    background-color: ${(props) => (props.isDark ? "#363636" : "#fff")};
-    flex-shrink: 0;
+  display: flex;
+  height: 3.15rem;
+  align-items: center;
+  background-color: ${(props) => (props.isDark ? "#363636" : "#fff")};
+  flex-shrink: 0;
 `;
 
 export const Logo = styled.div`
-    margin: 0 4rem 0 12.25rem;
+  margin: 0 4rem 0 12.25rem;
 
-    a img {
-        height: 2.1rem; /* 로고 이미지 높이 */
-        width: auto;
-    }
+  a img {
+    height: 2.1rem; /* 로고 이미지 높이 */
+    width: auto;
+  }
 `;
 
 export const NavItem = styled(Link)`
-    margin-left: 4rem;
-    font-size: 0.85rem;
-    font-weight: 400;
-    text-decoration: none;
-    color: ${(props) => {
+  margin-left: 4rem;
+  font-size: 0.85rem;
+  font-weight: 400;
+  text-decoration: none;
+  color: ${(props) => {
     const { currentPath, itemPath } = props;
 
     // Case 1: Home - both #000
@@ -31,12 +31,12 @@ export const NavItem = styled(Link)`
 
     // Case 2: News - News #FFF, Club Community #8F8F8F
     if (currentPath.includes("/news")) {
-        return itemPath === "/news" ? "#FFF" : "#8F8F8F";
+      return itemPath === "/news" ? "#FFF" : "#8F8F8F";
     }
 
     // Case 3: Club Community #FFF, News #8F8F8F
     if (currentPath.includes("/community")) {
-        return itemPath === "/community" ? "#FFF" : "#8F8F8F";
+      return itemPath === "/community" ? "#FFF" : "#8F8F8F";
     }
 
     // Case 4: Signup - same as profile settings (both #FFF)
@@ -44,26 +44,26 @@ export const NavItem = styled(Link)`
 
     // Default (fallback) using isDark prop
     return props.isDark ? "#FFF" : "#000";
-}};
+  }};
 `;
 
 export const LoginButton = styled(Link)`
-    display: ${(props) => (props.currentPath === "/signup" ? "flex" : "none")};
-    position: absolute;
-    right: 12.5rem;
-    height: 1.7rem;
-    padding: 0.4375rem 0.7875rem;
-    justify-content: center;
-    align-items: center;
-    gap: 0.4375rem;
-    border-radius: 0.875rem;
-    border: 1px solid #DCDCDC;
-    background: #FFF;
-    color: #C00C0B;
-    text-align: right;
-    font-size: 0.7875rem;
-    font-style: normal;
-    font-weight: 400;
-    line-height: 1rem; /* 133.333% */
-    text-decoration: none;
+  display: ${(props) => (props.currentPath === "/signup" ? "flex" : "none")};
+  position: absolute;
+  right: 12.5rem;
+  height: 1.7rem;
+  padding: 0.4375rem 0.7875rem;
+  justify-content: center;
+  align-items: center;
+  gap: 0.4375rem;
+  border-radius: 0.875rem;
+  border: 1px solid #dcdcdc;
+  background: #fff;
+  color: #c00c0b;
+  text-align: right;
+  font-size: 0.7875rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1rem; /* 133.333% */
+  text-decoration: none;
 `;

--- a/kickon-fe/src/components/RankingTable/rankingTable.jsx
+++ b/kickon-fe/src/components/RankingTable/rankingTable.jsx
@@ -1,92 +1,98 @@
-import React, {useState} from "react";
+import React, { useState } from "react";
 import * as S from "./rankingTable.style";
-import {League} from "../../mocks/league.js";
+import { League } from "../../mocks/league.js";
 import { IoChevronDown } from "react-icons/io5";
 
 const RankingTable = ({ title, rankings, type = "season" }) => {
-    const [isOpen, setIsOpen] = useState(false);
-    const [selectedLeague, setSelectedLeague] = useState("K리그 1");
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedLeague, setSelectedLeague] = useState("K리그 1");
 
-    const toggleDropdown = () => {
-        setIsOpen(!isOpen);
-    };
+  const toggleDropdown = () => {
+    setIsOpen(!isOpen);
+  };
 
-    const handleLeagueSelect = (league) => {
-        setSelectedLeague(league.krName);
-        setIsOpen(false);
-    };
+  const handleLeagueSelect = (league) => {
+    setSelectedLeague(league.krName);
+    setIsOpen(false);
+  };
 
-    return (
-        <S.TableContainer>
-            <S.Title>{title}</S.Title>
-            <S.Divider />
-            <S.LeagueSelector onClick={toggleDropdown}>
-                <span>{selectedLeague}</span>
-                <IoChevronDown size="0.7rem" color="#8F8F8F" />
-            </S.LeagueSelector>
+  return (
+    <S.TableContainer>
+      <S.Title>{title}</S.Title>
+      <S.Divider />
+      <S.LeagueSelector onClick={toggleDropdown}>
+        <span>{selectedLeague}</span>
+        <IoChevronDown size="0.7rem" color="#8F8F8F" />
+      </S.LeagueSelector>
 
-            {isOpen && (
-                <S.DropdownMenu>
-                    {League.map(league => (
-                        <S.TabOption key={league.pk} onClick={() => handleLeagueSelect(league)}>
-                            <S.LeagueImage src={league.logoUrl} alt={league.krName} />
-                            <S.LeagueName>{league.krName}</S.LeagueName>
-                        </S.TabOption>
-                    ))}
-                </S.DropdownMenu>
+      {isOpen && (
+        <S.DropdownMenu>
+          {League.map((league) => (
+            <S.TabOption
+              key={league.pk}
+              onClick={() => handleLeagueSelect(league)}
+            >
+              <S.LeagueImage src={league.logoUrl} alt={league.krName} />
+              <S.LeagueName>{league.krName}</S.LeagueName>
+            </S.TabOption>
+          ))}
+        </S.DropdownMenu>
+      )}
+
+      <S.Divider />
+
+      <S.Table>
+        <thead>
+          <S.HeaderRow type={type}>
+            <S.TableHeader align="left">순위</S.TableHeader>
+            <S.TableHeader align="center"></S.TableHeader>
+            {type === "season" ? (
+              <>
+                <S.TableHeader align="center">경기</S.TableHeader>
+                <S.TableHeader align="center">승점</S.TableHeader>
+                <S.TableHeader align="center">득점</S.TableHeader>
+              </>
+            ) : (
+              <>
+                <S.TableHeader />
+                <S.TableHeader align="center">경기</S.TableHeader>
+                <S.TableHeader align="center">점수</S.TableHeader>
+              </>
             )}
+          </S.HeaderRow>
+        </thead>
+        <tbody>
+          {rankings.slice(0, 10).map((item, index) => (
+            <S.TableRow key={index}>
+              <S.TableData>{item.rankOrder}</S.TableData>
 
-            <S.Divider />
+              <S.TeamCell>
+                <S.TeamLogo
+                  src={item.teamLogoUrl}
+                  alt={`${item.teamName} logo`}
+                />
+                <S.TableData>{item.teamName}</S.TableData>
+              </S.TeamCell>
 
-            <S.Table>
-                <thead>
-                <S.HeaderRow type={type}>
-                    <S.TableHeader align="left">순위</S.TableHeader>
-                    <S.TableHeader align="center"></S.TableHeader>
-                    {type === "season" ? (
-                        <>
-                            <S.TableHeader align="center">경기</S.TableHeader>
-                            <S.TableHeader align="center">승점</S.TableHeader>
-                            <S.TableHeader align="center">득점</S.TableHeader>
-                        </>
-                    ) : (
-                        <>
-                            <S.TableHeader />
-                            <S.TableHeader align="center">경기</S.TableHeader>
-                            <S.TableHeader align="center">점수</S.TableHeader>
-                        </>
-                    )}
-                </S.HeaderRow>
-                </thead>
-                <tbody>
-                {rankings.slice(0, 10).map((item, index) => (
-                    <S.TableRow key={index}>
-                        <S.TableData>{item.rankOrder}</S.TableData>
-
-                        <S.TeamCell>
-                            <S.TeamLogo src={item.teamLogoUrl} alt={`${item.teamName} logo`} />
-                            <S.TableData>{item.teamName}</S.TableData>
-                        </S.TeamCell>
-
-                        {type === "season" ? (
-                            <>
-                                <S.TableData>{item.gameNum}</S.TableData>
-                                <S.TableData>{item.points}</S.TableData>
-                                <S.TableData>{item.wonScores}</S.TableData>
-                            </>
-                        ) : (
-                            <>
-                                <S.TableData />
-                                <S.TableData>{item.gameNum}</S.TableData>
-                                <S.TableData>{item.points}</S.TableData>
-                            </>
-                        )}
-                    </S.TableRow>
-                ))}
-                </tbody>
-            </S.Table>
-        </S.TableContainer>
-    );
+              {type === "season" ? (
+                <>
+                  <S.TableData>{item.gameNum}</S.TableData>
+                  <S.TableData>{item.points}</S.TableData>
+                  <S.TableData>{item.wonScores}</S.TableData>
+                </>
+              ) : (
+                <>
+                  <S.TableData />
+                  <S.TableData>{item.gameNum}</S.TableData>
+                  <S.TableData>{item.points}</S.TableData>
+                </>
+              )}
+            </S.TableRow>
+          ))}
+        </tbody>
+      </S.Table>
+    </S.TableContainer>
+  );
 };
 
 export default RankingTable;

--- a/kickon-fe/src/components/RankingTable/rankingTable.jsx
+++ b/kickon-fe/src/components/RankingTable/rankingTable.jsx
@@ -1,71 +1,91 @@
-import React, { useState } from "react";
-import {
-    TableContainer,
-    Table,
-    TableHeader,
-    TableRow,
-    TableData,
-    Title,
-    Divider,
-    LeagueSelector,
-    DropdownArrow,
-    TeamCell,
-    TeamLogo,
-    TeamName,
-    HeaderRow
-} from "./rankingTable.style";
+import React, {useState} from "react";
+import * as S from "./rankingTable.style";
+import {League} from "../../mocks/league.js";
+import { IoChevronDown } from "react-icons/io5";
 
 const RankingTable = ({ title, rankings, type = "season" }) => {
     const [isOpen, setIsOpen] = useState(false);
+    const [selectedLeague, setSelectedLeague] = useState("K리그 1");
 
     const toggleDropdown = () => {
         setIsOpen(!isOpen);
     };
 
-    return (
-        <TableContainer>
-            <Title>{title}</Title>
-            <Divider />
-            <LeagueSelector onClick={toggleDropdown}>
-                K리그 1 <DropdownArrow isOpen={isOpen}>▼</DropdownArrow>
-            </LeagueSelector>
-            <Divider />
+    const handleLeagueSelect = (league) => {
+        setSelectedLeague(league.krName);
+        setIsOpen(false);
+    };
 
-            <Table>
+    return (
+        <S.TableContainer>
+            <S.Title>{title}</S.Title>
+            <S.Divider />
+            <S.LeagueSelector onClick={toggleDropdown}>
+                <span>{selectedLeague}</span>
+                <IoChevronDown size="0.7rem" color="#8F8F8F" />
+            </S.LeagueSelector>
+
+            {isOpen && (
+                <S.DropdownMenu>
+                    {League.map(league => (
+                        <S.TabOption key={league.pk} onClick={() => handleLeagueSelect(league)}>
+                            <S.LeagueImage src={league.logoUrl} alt={league.krName} />
+                            <S.LeagueName>{league.krName}</S.LeagueName>
+                        </S.TabOption>
+                    ))}
+                </S.DropdownMenu>
+            )}
+
+            <S.Divider />
+
+            <S.Table>
                 <thead>
-                <HeaderRow>
-                    <TableHeader align="left">순위</TableHeader>
-                    <TableHeader align="center"></TableHeader>
+                <S.HeaderRow type={type}>
+                    <S.TableHeader align="left">순위</S.TableHeader>
+                    <S.TableHeader align="center"></S.TableHeader>
                     {type === "season" ? (
                         <>
-                            <TableHeader align="center">경기</TableHeader>
-                            <TableHeader align="center">승점</TableHeader>
-                            <TableHeader align="center">득점</TableHeader>
+                            <S.TableHeader align="center">경기</S.TableHeader>
+                            <S.TableHeader align="center">승점</S.TableHeader>
+                            <S.TableHeader align="center">득점</S.TableHeader>
                         </>
                     ) : (
                         <>
-                            <TableHeader align="center">경기</TableHeader>
-                            <TableHeader align="center">점수</TableHeader>
+                            <S.TableHeader />
+                            <S.TableHeader align="center">경기</S.TableHeader>
+                            <S.TableHeader align="center">점수</S.TableHeader>
                         </>
                     )}
-                </HeaderRow>
+                </S.HeaderRow>
                 </thead>
                 <tbody>
                 {rankings.slice(0, 10).map((item, index) => (
-                    <TableRow key={index}>
-                        <TableData>{item.rankOrder}</TableData>
-                        <TeamCell>
-                            <TeamLogo src={item.teamLogoUrl} alt={`${item.teamName} logo`} />
-                            <TeamName>{item.teamName}</TeamName>
-                        </TeamCell>
-                        <TableData>{item.gameNum}</TableData>
-                        <TableData>{item.points}</TableData>
-                        {type === "season" && <TableData>{item.wonScores}</TableData>}
-                    </TableRow>
+                    <S.TableRow key={index}>
+                        <S.TableData>{item.rankOrder}</S.TableData>
+
+                        <S.TeamCell>
+                            <S.TeamLogo src={item.teamLogoUrl} alt={`${item.teamName} logo`} />
+                            <S.TableData>{item.teamName}</S.TableData>
+                        </S.TeamCell>
+
+                        {type === "season" ? (
+                            <>
+                                <S.TableData>{item.gameNum}</S.TableData>
+                                <S.TableData>{item.points}</S.TableData>
+                                <S.TableData>{item.wonScores}</S.TableData>
+                            </>
+                        ) : (
+                            <>
+                                <S.TableData />
+                                <S.TableData>{item.gameNum}</S.TableData>
+                                <S.TableData>{item.points}</S.TableData>
+                            </>
+                        )}
+                    </S.TableRow>
                 ))}
                 </tbody>
-            </Table>
-        </TableContainer>
+            </S.Table>
+        </S.TableContainer>
     );
 };
 

--- a/kickon-fe/src/components/RankingTable/rankingTable.style.js
+++ b/kickon-fe/src/components/RankingTable/rankingTable.style.js
@@ -1,65 +1,66 @@
 import styled from "styled-components";
 
 export const TableContainer = styled.div`
-    width: 15rem; 
-    background-color: #FFF;
-    border-radius: 0.45rem;
-    border: 1px solid #DCDCDC;
-    padding-bottom: 0.75rem;
-    gap: 0.75rem;
+  width: 15rem;
+  background-color: #fff;
+  border-radius: 0.45rem;
+  border: 1px solid #dcdcdc;
+  padding-bottom: 0.75rem;
+  gap: 0.75rem;
 `;
 
 export const Title = styled.p`
-    // 순위 이름
-    font-size: 0.75rem;
-    font-weight: 600;
-    color: #000;
-    font-style: normal;
-    line-height: 1rem;
-    margin: 0;
-    padding: 0.75rem 0.75rem 0 0.75rem;
+  // 순위 이름
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #000;
+  font-style: normal;
+  line-height: 1rem;
+  margin: 0;
+  padding: 0.75rem 0.75rem 0 0.75rem;
 `;
 
 export const Divider = styled.hr`
-    height: 0;
-    border: 0;
-    border-top: 1px solid #F0F0F0;
-    margin: 0.7rem 0;
+  height: 0;
+  border: 0;
+  border-top: 1px solid #f0f0f0;
+  margin: 0.7rem 0;
 `;
 
-export const LeagueSelector = styled.div` // k리그
-    display: flex;
-    align-items: center;
-    font-size: 0.7rem;
-    font-weight: 1000;
-    color: #000;
-    cursor: pointer;
-    gap: 0.28rem;
-    padding: 0 0.75rem;
+export const LeagueSelector = styled.div`
+  // k리그
+  display: flex;
+  align-items: center;
+  font-size: 0.7rem;
+  font-weight: 1000;
+  color: #000;
+  cursor: pointer;
+  gap: 0.28rem;
+  padding: 0 0.75rem;
 
-    & > span {
-        font-size: 0.6475rem;
-        font-style: normal;
-        font-weight: 500;
-        line-height: 1rem;
-    }
+  & > span {
+    font-size: 0.6475rem;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 1rem;
+  }
 `;
 
 export const DropdownMenu = styled.div`
-    // 드롭다운 컨테이너
-    position: absolute;
-    width: 8.8rem;
-    z-index: 10;
-    margin: 0.4rem 0 0 0.4rem;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    gap: 0.35rem;
-    align-self: stretch;
-    border-radius: 0.4375rem;
-    border: 0.7px solid #F0F0F0;
-    background: #FFF;
-    box-shadow: 0 3px 11px 0 rgba(0, 0, 0, 0.20);
+  // 드롭다운 컨테이너
+  position: absolute;
+  width: 8.8rem;
+  z-index: 10;
+  margin: 0.4rem 0 0 0.4rem;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 0.35rem;
+  align-self: stretch;
+  border-radius: 0.4375rem;
+  border: 0.7px solid #f0f0f0;
+  background: #fff;
+  box-shadow: 0 3px 11px 0 rgba(0, 0, 0, 0.2);
 `;
 
 export const LeagueImage = styled.img`
@@ -78,79 +79,80 @@ export const LeagueName = styled.span`
 `;
 
 export const TabOption = styled.div`
-    // 드롭다운 각 리그
-    width: 100%;
-    color: #000;
-    font-size: 0.65rem;
-    padding: 0.3rem 0;
-    cursor: pointer;
-    align-items: center;
+  // 드롭다운 각 리그
+  width: 100%;
+  color: #000;
+  font-size: 0.65rem;
+  padding: 0.3rem 0;
+  cursor: pointer;
+  align-items: center;
 
-    &:hover {
-        background-color: #F0F0F0;
+  &:hover {
+    background-color: #f0f0f0;
 
-        ${LeagueName} {
-            font-weight: 400;
-        }
+    ${LeagueName} {
+      font-weight: 400;
     }
+  }
 
-    & + & {
-        border-top: 1px solid #F0F0F0;
-    }
+  & + & {
+    border-top: 1px solid #f0f0f0;
+  }
 `;
 
-export const Table = styled.table` // 각 행
-    width: 100%;
-    display: flex;
-    border-collapse: collapse;
-    flex-direction: column;
-    align-self: stretch;
-    padding: 0 0.75rem
+export const Table = styled.table`
+  // 각 행
+  width: 100%;
+  display: flex;
+  border-collapse: collapse;
+  flex-direction: column;
+  align-self: stretch;
+  padding: 0 0.75rem;
 `;
 
 export const HeaderRow = styled.tr`
-    display: grid;
-    grid-template-columns: 1.66rem auto 1.2rem 1.2rem 1.2rem; // ✅ 데이터와 같은 너비
-    align-items: center;
-    padding: 0.25rem 0;
-    column-gap: 0.35rem;
+  display: grid;
+  grid-template-columns: 1.66rem auto 1.2rem 1.2rem 1.2rem; // ✅ 데이터와 같은 너비
+  align-items: center;
+  padding: 0.25rem 0;
+  column-gap: 0.35rem;
 `;
 
 export const TableHeader = styled.th`
-    text-align: center;
-    font-weight: normal;
-    color: #676767;
-    font-size: 0.62rem;
-    padding-bottom: 0.75rem;
+  text-align: center;
+  font-weight: normal;
+  color: #676767;
+  font-size: 0.62rem;
+  padding-bottom: 0.75rem;
 `;
 
 export const TableRow = styled.tr`
-    display: grid;
-    grid-template-columns: 1.66rem auto 1.2rem 1.2rem 1.2rem;
-    align-items: center;
-    padding: 0.2rem 0;
-    column-gap: 0.35rem;
+  display: grid;
+  grid-template-columns: 1.66rem auto 1.2rem 1.2rem 1.2rem;
+  align-items: center;
+  padding: 0.2rem 0;
+  column-gap: 0.35rem;
 `;
 
 export const TableData = styled.td`
-    color: #000;
-    font-size: 0.65rem;
-    font-style: normal;
-    font-weight: 500;
-    line-height: 1.125rem;
-    text-align: center;
+  color: #000;
+  font-size: 0.65rem;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 1.125rem;
+  text-align: center;
 `;
 
 export const TeamCell = styled.td`
-    display: flex;
-    align-items: center;
-    padding: 0;
-    justify-content: start;
+  display: flex;
+  align-items: center;
+  padding: 0;
+  justify-content: start;
 `;
 
 export const TeamLogo = styled.img`
-    width: 0.7875rem;
-    height: 0.7875rem;
-    margin-right: 0.5rem;
-    object-fit: contain;
+  width: 0.7875rem;
+  height: 0.7875rem;
+  margin-right: 0.5rem;
+  object-fit: contain;
 `;

--- a/kickon-fe/src/components/RankingTable/rankingTable.style.js
+++ b/kickon-fe/src/components/RankingTable/rankingTable.style.js
@@ -35,7 +35,7 @@ export const LeagueSelector = styled.div` // k리그
     color: #000;
     cursor: pointer;
     gap: 0.28rem;
-        padding: 0 0.75rem;
+    padding: 0 0.75rem;
 
     & > span {
         font-size: 0.6475rem;
@@ -101,43 +101,44 @@ export const TabOption = styled.div`
 
 export const Table = styled.table` // 각 행
     width: 100%;
-        display: flex;
+    display: flex;
     border-collapse: collapse;
-        flex-direction: column;
-        align-self: stretch;
-        padding: 0 0.75rem
+    flex-direction: column;
+    align-self: stretch;
+    padding: 0 0.75rem
 `;
 
 export const HeaderRow = styled.tr`
-        display: grid;
-        grid-template-columns: 1.66rem auto 1.2rem 1.2rem 1.2rem; // ✅ 데이터와 같은 너비
-        align-items: center;
-        padding: 0.25rem 0;
-        column-gap: 0.35rem;
+    display: grid;
+    grid-template-columns: 1.66rem auto 1.2rem 1.2rem 1.2rem; // ✅ 데이터와 같은 너비
+    align-items: center;
+    padding: 0.25rem 0;
+    column-gap: 0.35rem;
 `;
 
 export const TableHeader = styled.th`
     text-align: center;
     font-weight: normal;
     color: #676767;
-    font-size: 0.6rem;
+    font-size: 0.62rem;
+    padding-bottom: 0.75rem;
 `;
 
 export const TableRow = styled.tr`
     display: grid;
     grid-template-columns: 1.66rem auto 1.2rem 1.2rem 1.2rem;
     align-items: center;
-    padding: 0.25rem 0;
-        column-gap: 0.35rem;
+    padding: 0.2rem 0;
+    column-gap: 0.35rem;
 `;
 
 export const TableData = styled.td`
     color: #000;
-        font-size: 0.6rem;
-        font-style: normal;
-        font-weight: 500;
-        line-height: 1.125rem;
-        text-align: center;
+    font-size: 0.65rem;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 1.125rem;
+    text-align: center;
 `;
 
 export const TeamCell = styled.td`

--- a/kickon-fe/src/components/RankingTable/rankingTable.style.js
+++ b/kickon-fe/src/components/RankingTable/rankingTable.style.js
@@ -2,24 +2,29 @@ import styled from "styled-components";
 
 export const TableContainer = styled.div`
     width: 15rem; 
-    background-color: #ffffff;
-    border-radius: 0.4rem;
-    box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.05);
-    padding: 1rem;
+    background-color: #FFF;
+    border-radius: 0.45rem;
+    border: 1px solid #DCDCDC;
+    padding-bottom: 0.75rem;
+    gap: 0.75rem;
 `;
 
 export const Title = styled.p`
-    margin: 0;
+    // 순위 이름
     font-size: 0.75rem;
-    font-weight: bold;
-    color: #333;
+    font-weight: 600;
+    color: #000;
+    font-style: normal;
+    line-height: 1rem;
+    margin: 0;
+    padding: 0.75rem 0.75rem 0 0.75rem;
 `;
 
 export const Divider = styled.hr`
+    height: 0;
     border: 0;
-    height: 0.0625rem;
-    background-color: #eeeeee;
-    margin: 0.75rem 0;
+    border-top: 1px solid #F0F0F0;
+    margin: 0.7rem 0;
 `;
 
 export const LeagueSelector = styled.div` // k리그
@@ -27,70 +32,124 @@ export const LeagueSelector = styled.div` // k리그
     align-items: center;
     font-size: 0.7rem;
     font-weight: 1000;
-    color: #333;
+    color: #000;
     cursor: pointer;
+    gap: 0.28rem;
+        padding: 0 0.75rem;
 
     & > span {
-        margin-left: 0.5rem; 
+        font-size: 0.6475rem;
+        font-style: normal;
+        font-weight: 500;
+        line-height: 1rem;
     }
 `;
 
-export const DropdownArrow = styled.span` // 수정
-    transition: transform 0.3s ease;
-    transform: ${props => props.isOpen ? 'rotate(180deg)' : 'rotate(0)'};
-    display: inline-block;
-    font-size: 0.75rem;
-    color: #666;
+export const DropdownMenu = styled.div`
+    // 드롭다운 컨테이너
+    position: absolute;
+    width: 8.8rem;
+    z-index: 10;
+    margin-top: 0.4rem;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 0.35rem;
+    align-self: stretch;
+    border-radius: 0.4375rem;
+    border: 0.7px solid #F0F0F0;
+    background: #FFF;
+    box-shadow: 0 3px 11px 0 rgba(0, 0, 0, 0.20);
+`;
+
+export const LeagueImage = styled.img`
+  width: 0.7rem;
+  height: 0.7rem;
+  margin-left: 1rem;
+`;
+
+export const LeagueName = styled.span`
+  margin-left: 0.7rem;
+  color: #000;
+  font-size: 0.62rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 0.7rem;
+`;
+
+export const TabOption = styled.div`
+    // 드롭다운 각 리그
+    width: 100%;
+    color: #000;
+    font-size: 0.65rem;
+    padding: 0.3rem 0;
+    cursor: pointer;
+    align-items: center;
+
+    &:hover {
+        background-color: #F0F0F0;
+
+        ${LeagueName} {
+            font-weight: 400;
+        }
+    }
+
+    & + & {
+        border-top: 1px solid #F0F0F0;
+    }
 `;
 
 export const Table = styled.table` // 각 행
     width: 100%;
+        display: flex;
     border-collapse: collapse;
+        flex-direction: column;
+        align-self: stretch;
+        padding: 0 0.75rem
 `;
 
 export const HeaderRow = styled.tr`
-    display: grid;
-    grid-template-columns: 2.5rem 1fr 2rem 2rem 2rem;
-    padding: 0.25rem 0;
-    color: #666;
-    font-size: 0.7rem;
+        display: grid;
+        grid-template-columns: 1.66rem auto 1.2rem 1.2rem 1.2rem; // ✅ 데이터와 같은 너비
+        align-items: center;
+        padding: 0.25rem 0;
+        column-gap: 0.35rem;
 `;
 
 export const TableHeader = styled.th`
-    text-align: ${props => props.align || 'center'};
+    text-align: center;
     font-weight: normal;
-    color: #666;
-    font-size: 0.7rem;
+    color: #676767;
+    font-size: 0.6rem;
 `;
 
 export const TableRow = styled.tr`
     display: grid;
-    grid-template-columns: 1rem 1fr 2rem 2rem 1.5rem;
+    grid-template-columns: 1.66rem auto 1.2rem 1.2rem 1.2rem;
     align-items: center;
     padding: 0.25rem 0;
+        column-gap: 0.35rem;
 `;
 
 export const TableData = styled.td`
-    text-align: ${props => props.align || 'left'};
-    font-size: 0.7rem; 
-    width: ${props => props.width || 'auto'};
     color: #000;
+        font-size: 0.6rem;
+        font-style: normal;
+        font-weight: 500;
+        line-height: 1.125rem;
+        text-align: center;
 `;
 
 export const TeamCell = styled.td`
     display: flex;
     align-items: center;
     padding: 0;
+    justify-content: start;
 `;
 
 export const TeamLogo = styled.img`
-    width: 1.25rem;
-    height: 1.25rem;
+    width: 0.7875rem;
+    height: 0.7875rem;
     margin-right: 0.5rem;
     object-fit: contain;
-`;
-
-export const TeamName = styled.span`
-    font-size: 0.7rem;
-    color: #000;
 `;

--- a/kickon-fe/src/components/RankingTable/rankingTable.style.js
+++ b/kickon-fe/src/components/RankingTable/rankingTable.style.js
@@ -2,7 +2,6 @@ import styled from "styled-components";
 
 export const TableContainer = styled.div`
     width: 15rem; 
-    margin-left: 3rem; 
     background-color: #ffffff;
     border-radius: 0.4rem;
     box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.05);

--- a/kickon-fe/src/components/RankingTable/rankingTable.style.js
+++ b/kickon-fe/src/components/RankingTable/rankingTable.style.js
@@ -50,7 +50,7 @@ export const DropdownMenu = styled.div`
     position: absolute;
     width: 8.8rem;
     z-index: 10;
-    margin-top: 0.4rem;
+    margin: 0.4rem 0 0 0.4rem;
     flex-direction: column;
     justify-content: center;
     align-items: center;

--- a/kickon-fe/src/layout/root-layout.jsx
+++ b/kickon-fe/src/layout/root-layout.jsx
@@ -22,7 +22,7 @@ const MainContainer = styled.div`
   display: flex;
   justify-content: center;
   width: 100%;
-  padding: 2rem 1rem;
+  padding: 0.7rem;
 `;
 
 // 좌/중앙/우측 컬럼 묶는 wrapper

--- a/kickon-fe/src/layout/root-layout.jsx
+++ b/kickon-fe/src/layout/root-layout.jsx
@@ -8,56 +8,67 @@ import TopNews from "../components/TopNews/topNews";
 import Footer from "../components/Footer/footer";
 import styled from "styled-components";
 import {rankings} from "../mocks/rankings.js";
-import CommunityBoard from "../components/CommunityBoard/communityBoard.jsx";
 
+// 전체 레이아웃 Wrapper
 const Layout = styled.div`
-    display: flex;
-    flex-direction: column;
-    min-height: 100vh;
-    background-color: ${props => props.isHomePage ? "#363636" : "#F8F8F8"};
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background-color: ${props => props.isHomePage ? "#363636" : "#F8F8F8"};
 `;
 
+// 메인 영역
 const MainContainer = styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 1rem; /* 20px */
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  padding: 2rem 1rem;
 `;
 
+// 좌/중앙/우측 컬럼 묶는 wrapper
 const ContentWrapper = styled.div`
-    display: flex;
-    flex-direction: row;
-    //width: 59rem; /* 전체 콘텐츠 너비 */
-    gap: 1rem; /* 컬럼 간 여백 */
+  display: flex;
+  gap: 1rem;
+  width: 100%;
+  max-width: calc(15rem + 1rem + 30rem + 1rem + 15rem + 24.5rem); // 총 여백 포함
+  padding: 0 12.25rem;
+  box-sizing: border-box;
+
+  @media (max-width: 1200px) {
+    padding: 0 2rem;
+  }
 `;
 
+// 개별 컬럼 스타일
 const LeftColumn = styled.div`
-    //width: 13.5rem;
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    margin-left: 12rem; /* 왼쪽 여백 */
+  width: 15rem;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
 `;
 
 const MainContent = styled.main`
-    display: flex;
-    flex-direction: column;
-    width: 30rem; /* 메인 콘텐츠 너비 */
-    gap: 1rem;
+  width: 30rem;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
 `;
 
 const RightColumn = styled.div`
-    //width: 13.5rem;
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    margin-right: 12rem; /* 오른쪽 여백 */
-    //align-items: flex-end;
+  width: 15rem;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
 `;
 
+// 메인 배너
 const StyledMainBanner = styled(MainBanner)`
+    width: 100%;
     max-width: 100%;
-`;
+`
 
 const RootLayout = () => {
     const location = useLocation();
@@ -70,7 +81,6 @@ const RootLayout = () => {
         <Layout isHomePage={isHomePage}>
             <Header isDark={isDark} />
 
-            {/* 홈 화면일 때만 배너 표시 */}
             {isHomePage && <StyledMainBanner />}
 
             <MainContainer>
@@ -80,18 +90,15 @@ const RootLayout = () => {
                     </MainContent>
                 ) : (
                     <ContentWrapper>
-                        {/* 왼쪽: 랭킹 테이블 */}
                         <LeftColumn>
                             <RankingTable title="이번 시즌 순위" rankings={rankings} type="season" />
                             <RankingTable title="승부예측 순위" rankings={rankings} type="prediction" />
                         </LeftColumn>
 
-                        {/* 중앙: 페이지별 메인 콘텐츠 */}
                         <MainContent>
                             <Outlet />
                         </MainContent>
 
-                        {/* 오른쪽: 프로필 */}
                         <RightColumn>
                             <Profile />
                             <TopNews />
@@ -100,7 +107,6 @@ const RootLayout = () => {
                 )}
             </MainContainer>
 
-            {/* 홈 또는 회원가입일 때 Footer 표시 */}
             {(isHomePage || isSignupPage) && <Footer isDark={isSignupPage} />}
         </Layout>
     );

--- a/kickon-fe/src/layout/root-layout.jsx
+++ b/kickon-fe/src/layout/root-layout.jsx
@@ -7,14 +7,14 @@ import Profile from "../components/Profile/profile";
 import TopNews from "../components/TopNews/topNews";
 import Footer from "../components/Footer/footer";
 import styled from "styled-components";
-import {rankings} from "../mocks/rankings.js";
+import { rankings } from "../mocks/rankings.js";
 
 // 전체 레이아웃 Wrapper
 const Layout = styled.div`
   display: flex;
   flex-direction: column;
   min-height: 100vh;
-  background-color: ${props => props.isHomePage ? "#363636" : "#F8F8F8"};
+  background-color: ${(props) => (props.isHomePage ? "#363636" : "#F8F8F8")};
 `;
 
 // 메인 영역
@@ -30,7 +30,9 @@ const ContentWrapper = styled.div`
   display: flex;
   gap: 1rem;
   width: 100%;
-  max-width: calc(15rem + 1rem + 30rem + 1rem + 15rem + 24.5rem); // 총 여백 포함
+  max-width: calc(
+    15rem + 1rem + 30rem + 1rem + 15rem + 24.5rem
+  ); // 총 여백 포함
   padding: 0 12.25rem;
   box-sizing: border-box;
 
@@ -66,50 +68,60 @@ const RightColumn = styled.div`
 
 // 메인 배너
 const StyledMainBanner = styled(MainBanner)`
-    width: 100%;
-    max-width: 100%;
-`
+  width: 100%;
+  max-width: 100%;
+`;
 
 const RootLayout = () => {
-    const location = useLocation();
-    const isHomePage = location.pathname === "/";
-    const isSignupPage = location.pathname === "/signup";
-    const isDark = !isHomePage; // 홈 이외의 페이지에서 다크 모드 적용
-    const isWritePage = location.pathname === "/news/write" || location.pathname === "/community/write";
+  const location = useLocation();
+  const isHomePage = location.pathname === "/";
+  const isSignupPage = location.pathname === "/signup";
+  const isDark = !isHomePage; // 홈 이외의 페이지에서 다크 모드 적용
+  const isWritePage =
+    location.pathname === "/news/write" ||
+    location.pathname === "/community/write";
 
-    return (
-        <Layout isHomePage={isHomePage}>
-            <Header isDark={isDark} />
+  return (
+    <Layout isHomePage={isHomePage}>
+      <Header isDark={isDark} />
 
-            {isHomePage && <StyledMainBanner />}
+      {isHomePage && <StyledMainBanner />}
 
-            <MainContainer>
-                {isSignupPage || isWritePage ? (
-                    <MainContent>
-                        <Outlet />
-                    </MainContent>
-                ) : (
-                    <ContentWrapper>
-                        <LeftColumn>
-                            <RankingTable title="이번 시즌 순위" rankings={rankings} type="season" />
-                            <RankingTable title="승부예측 순위" rankings={rankings} type="prediction" />
-                        </LeftColumn>
+      <MainContainer>
+        {isSignupPage || isWritePage ? (
+          <MainContent>
+            <Outlet />
+          </MainContent>
+        ) : (
+          <ContentWrapper>
+            <LeftColumn>
+              <RankingTable
+                title="이번 시즌 순위"
+                rankings={rankings}
+                type="season"
+              />
+              <RankingTable
+                title="승부예측 순위"
+                rankings={rankings}
+                type="prediction"
+              />
+            </LeftColumn>
 
-                        <MainContent>
-                            <Outlet />
-                        </MainContent>
+            <MainContent>
+              <Outlet />
+            </MainContent>
 
-                        <RightColumn>
-                            <Profile />
-                            <TopNews />
-                        </RightColumn>
-                    </ContentWrapper>
-                )}
-            </MainContainer>
+            <RightColumn>
+              <Profile />
+              <TopNews />
+            </RightColumn>
+          </ContentWrapper>
+        )}
+      </MainContainer>
 
-            {(isHomePage || isSignupPage) && <Footer isDark={isSignupPage} />}
-        </Layout>
-    );
+      {(isHomePage || isSignupPage) && <Footer isDark={isSignupPage} />}
+    </Layout>
+  );
 };
 
 export default RootLayout;


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #39 

## ✨ 작업 개요
> 작업 내용을 간략하게 작성해주세요.
- 페이지 이동시 적용되는 헤더의 프로퍼티를 적용했습니다.
- rankingTable을 피그마의 디자인과 유사하게 수정했습니다.

## 📷 이미지 첨부 (선택)
- 작업 결과를 확인할 수 있는 이미지나 GIF를 첨부해주세요.  
- UI 변경, API 응답 샘플, 테스트 결과 등이 포함되면 좋아요!
- 헤더 프로퍼티/순위 테이블 변경 화면
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/afce5e39-8b50-444a-a84b-dee07bb65ae2" />

- 드롭다운 적용
<img width="1582" alt="image" src="https://github.com/user-attachments/assets/998201da-401b-4b60-8c06-ee70acde8efb" />

- 회원가입 페이지 헤더 로그인 버튼 생성
<img width="1582" alt="image" src="https://github.com/user-attachments/assets/c413d5a1-0009-43e5-9eca-f30df20b78e1" />


## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
