### PR TITLE
Feat: 글 작성 버튼 컴포넌트 구현

### DIFF
--- a/kickon-fe/src/components/WriteButton/writeButton.jsx
+++ b/kickon-fe/src/components/WriteButton/writeButton.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { FiEdit2 } from "react-icons/fi";
+import { useNavigate, useLocation } from "react-router-dom";
+import * as S from "./writeButton.style";
+
+const WriteButton = () => {
+    const navigate = useNavigate();
+    const location = useLocation();
+
+    const handleClick = () => {
+        if (location.pathname.startsWith("/news")) {
+            navigate("/news/write");
+        } else if (location.pathname.startsWith("/community")) {
+            navigate("/community/write");
+        }
+    };
+
+    return (
+        <S.FloatingButton onClick={handleClick}>
+            <S.Icon>
+                <FiEdit2 />
+            </S.Icon>
+            <S.Text>새로운 글 작성하기</S.Text>
+        </S.FloatingButton>
+    );
+};
+
+export default WriteButton;

--- a/kickon-fe/src/components/WriteButton/writeButton.style.js
+++ b/kickon-fe/src/components/WriteButton/writeButton.style.js
@@ -17,7 +17,7 @@ export const FloatingButton = styled.button`
     width: 2.7rem;
     height: 2.7rem;
     overflow: hidden;
-    position: relative; /* Added position relative */
+    position: relative;
 
     &:hover {
         width: 15rem;
@@ -31,22 +31,22 @@ export const Icon = styled.div`
     font-size: 1.3rem;
     color: white;
     flex-shrink: 0;
-    transition: margin-right 0.3s ease;
+    transition: margin-right 0.5s ease; /* Match the button transition timing */
 
     ${FloatingButton}:hover & {
-        margin-right: 0.35rem;
+        margin-right: 0.6rem;
     }
 `;
 
 export const Text = styled.span`
     opacity: 0;
-    display: none;
-    transition: opacity 0.3s ease, visibility 0.3s ease;
+    max-width: 0;
+    transition: opacity 0.3s ease, max-width 0.5s ease;
     white-space: nowrap;
+    overflow: hidden;
 
     ${FloatingButton}:hover & {
-        display: inline;
         opacity: 1;
-        visibility: visible;
+        max-width: 200px; /* Allow enough space for the text */
     }
 `;

--- a/kickon-fe/src/components/WriteButton/writeButton.style.js
+++ b/kickon-fe/src/components/WriteButton/writeButton.style.js
@@ -1,0 +1,52 @@
+import styled from "styled-components";
+
+export const FloatingButton = styled.button`
+    margin-top: 6.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: #676767;
+    color: white;
+    border: none;
+    border-radius: 2.3rem;
+    padding: 0.7rem;
+    font-size: 0.75rem;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: width 0.5s ease;
+    width: 2.7rem;
+    height: 2.7rem;
+    overflow: hidden;
+    position: relative; /* Added position relative */
+
+    &:hover {
+        width: 15rem;
+    }
+`;
+
+export const Icon = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.3rem;
+    color: white;
+    flex-shrink: 0;
+    transition: margin-right 0.3s ease;
+
+    ${FloatingButton}:hover & {
+        margin-right: 0.35rem;
+    }
+`;
+
+export const Text = styled.span`
+    opacity: 0;
+    display: none;
+    transition: opacity 0.3s ease, visibility 0.3s ease;
+    white-space: nowrap;
+
+    ${FloatingButton}:hover & {
+        display: inline;
+        opacity: 1;
+        visibility: visible;
+    }
+`;

--- a/kickon-fe/src/layout/root-layout.jsx
+++ b/kickon-fe/src/layout/root-layout.jsx
@@ -8,6 +8,7 @@ import TopNews from "../components/TopNews/topNews";
 import Footer from "../components/Footer/footer";
 import styled from "styled-components";
 import { rankings } from "../mocks/rankings.js";
+import WriteButton from "../components/WriteButton/writeButton.jsx";
 
 // 전체 레이아웃 Wrapper
 const Layout = styled.div`
@@ -80,6 +81,8 @@ const RootLayout = () => {
   const isWritePage =
     location.pathname === "/news/write" ||
     location.pathname === "/community/write";
+  const isNewsPage = location.pathname.startsWith("/news");
+  const isCommunityPage = location.pathname.startsWith("/community");
 
   return (
     <Layout isHomePage={isHomePage}>
@@ -114,6 +117,7 @@ const RootLayout = () => {
             <RightColumn>
               <Profile />
               <TopNews />
+                {((isNewsPage || isCommunityPage) && !isWritePage) && <WriteButton />}
             </RightColumn>
           </ContentWrapper>
         )}


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #48 

## ✨ 작업 개요
> 작업 내용을 간략하게 작성해주세요.
- 글 작성 컴포넌트를 구현했습니다
- 뉴스/커뮤니티 페이지에서 보이며, 클릭 시 글 작성 페이지로 이동합니다.

## 📷 이미지 첨부 (선택)
- 작업 결과를 확인할 수 있는 이미지나 GIF를 첨부해주세요.  
- UI 변경, API 응답 샘플, 테스트 결과 등이 포함되면 좋아요!

<img width="1582" alt="image" src="https://github.com/user-attachments/assets/7b012336-53c9-4c37-936f-05e6af06a059" />
<img width="1582" alt="image" src="https://github.com/user-attachments/assets/1f156850-ed23-4e06-a9d2-c5c93ced68b4" />
- 호버 

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
