### PR TITLE
Feat: 뉴스 리스트 조회 API 연결

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,7 +30,9 @@ function App() {
                             <Route path="news/write" element={<PostEditor type="news" />} />
                             <Route path="community/write" element={<PostEditor type="community" />} />
                             <Route path="news/detail" element={<NewsDetailPage />} />
+                            <Route path="news/:id" element={<NewsDetailPage />} />
                             <Route path="community/detail" element={<CommunityDetailPage />} />
+                            <Route path="community/:id" element={<CommunityDetailPage />} />
                         </Route>
                         <Route path="*" element={<NotFound />} />
                     </Routes>

--- a/src/apis/domains/news/getNewsList.js
+++ b/src/apis/domains/news/getNewsList.js
@@ -1,0 +1,22 @@
+import axiosInstance from "../../axios-instance.js";
+
+export const getNewsList = async ({ team, size, page, order, league }) => {
+    try {
+        const response = await axiosInstance.get('/api/news', {
+            params: { team, size, page, order, league },
+        });
+
+        console.log('API Response:', response);
+
+        // Validate the response structure
+        if (response?.code === 'GET_SUCCESS') {
+            return response;
+        } else {
+            console.error('Unexpected response format:', response.data);
+            return { data: [], meta: { totalPages: 1 } }; // Return default structure
+        }
+    } catch (error) {
+        console.error('뉴스 리스트 조회 실패: ', error);
+        return { data: [], meta: { totalPages: 1 } }; // Return default structure on error
+    }
+};

--- a/src/components/League/leagueDropdown.jsx
+++ b/src/components/League/leagueDropdown.jsx
@@ -3,7 +3,7 @@ import { IoIosArrowDown } from "react-icons/io";
 import * as S from "./leagueDropdown.style.js";
 import {getLeagues} from "../../apis/domains/common/getLeagues.js";
 
-const LeagueDropdown = ({selectedLeague, setSelectedLeague}) => {
+const LeagueDropdown = ({selectedLeague, setSelectedLeague, activeTab}) => {
     const [isDropdownOpen, setIsDropdownOpen] = useState(false);
     const [leagues, setLeagues] = useState([]);
 
@@ -12,7 +12,7 @@ const LeagueDropdown = ({selectedLeague, setSelectedLeague}) => {
     };
 
     const handleLeagueSelect = (league) => {
-        setSelectedLeague(league.krName);
+        setSelectedLeague(league); // 전체 리그 객체 저장
         setIsDropdownOpen(false);
     };
 
@@ -31,8 +31,11 @@ const LeagueDropdown = ({selectedLeague, setSelectedLeague}) => {
 
     return (
         <S.DropdownContainer>
-            <S.TabSelector onClick={toggleDropdown} selected={isDropdownOpen}>
-                <span>{selectedLeague}</span>
+            <S.TabSelector
+                onClick={toggleDropdown}
+                isActive={selectedLeague?.nameKr === activeTab} // 👈 드롭다운도 현재 탭인지 체크!
+            >
+                <span>{selectedLeague?.nameKr || "리그 선택"}</span>
                 <IoIosArrowDown size="0.7rem" color="#8F8F8F" />
             </S.TabSelector>
 

--- a/src/components/League/leagueDropdown.jsx
+++ b/src/components/League/leagueDropdown.jsx
@@ -1,0 +1,53 @@
+import React, {useEffect, useState} from "react";
+import { IoIosArrowDown } from "react-icons/io";
+import * as S from "./leagueDropdown.style.js";
+import {getLeagues} from "../../apis/domains/common/getLeagues.js";
+
+const LeagueDropdown = ({selectedLeague, setSelectedLeague}) => {
+    const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+    const [leagues, setLeagues] = useState([]);
+
+    const toggleDropdown = () => {
+        setIsDropdownOpen(!isDropdownOpen);
+    };
+
+    const handleLeagueSelect = (league) => {
+        setSelectedLeague(league.krName);
+        setIsDropdownOpen(false);
+    };
+
+    useEffect(() => {
+        const fetchLeagues = async () => {
+            try {
+                const data = await getLeagues();
+                setLeagues(data);
+            } catch (error) {
+                console.error("Failed to fetch leagues:", error);
+            }
+        };
+
+        fetchLeagues();
+    }, []);
+
+    return (
+        <S.DropdownContainer>
+            <S.TabSelector onClick={toggleDropdown} selected={isDropdownOpen}>
+                <span>{selectedLeague}</span>
+                <IoIosArrowDown size="0.7rem" color="#8F8F8F" />
+            </S.TabSelector>
+
+            {isDropdownOpen && (
+                <S.DropdownMenu>
+                    {leagues.map(league => (
+                        <S.TabOption key={league.pk} onClick={() => handleLeagueSelect(league)}>
+                            <S.LeagueImage src={league.logoUrl} alt={league.nameKr} />
+                            <S.LeagueName>{league.nameKr}</S.LeagueName>
+                        </S.TabOption>
+                    ))}
+                </S.DropdownMenu>
+            )}
+        </S.DropdownContainer>
+    );
+};
+
+export default LeagueDropdown;

--- a/src/components/League/leagueDropdown.style.js
+++ b/src/components/League/leagueDropdown.style.js
@@ -5,25 +5,24 @@ export const DropdownContainer = styled.div`
 `;
 
 export const TabSelector = styled.div`
-    // 리그 선택 탭
-    display: flex;
-    width: auto;
-    justify-content: space-between;
-    align-items: center;
-    align-self: stretch;
-    border-radius: 0.37rem;
-    background: #FFF;
-    font-size: 0.65rem;
-    cursor: pointer;
+  display: flex;
+  width: auto;
+  justify-content: space-between;
+  align-items: center;
+  align-self: stretch;
+  border-radius: 0.37rem;
+  background: #FFF;
+  font-size: 0.65rem;
+  cursor: pointer;
 
-    span {
-        color: #000;
-        font-weight: 400;
-        font-size: 0.7rem;
-        font-style: normal;
-        line-height: 0.7rem;
-        margin-right: 0.2rem;
-    }
+  span {
+    color: ${({ isActive }) => (isActive ? '#C00C0B' : '#000')};
+    font-weight: ${({ isActive }) => (isActive ? 500 : 400)};
+    font-size: 0.7rem;
+    font-style: normal;
+    line-height: 0.7rem;
+    margin-right: 0.2rem;
+  }
 `;
 
 export const DropdownMenu = styled.div`

--- a/src/components/League/leagueDropdown.style.js
+++ b/src/components/League/leagueDropdown.style.js
@@ -1,0 +1,81 @@
+import styled from "styled-components";
+
+export const DropdownContainer = styled.div`
+  position: relative;
+`;
+
+export const TabSelector = styled.div`
+    // 리그 선택 탭
+    display: flex;
+    width: auto;
+    justify-content: space-between;
+    align-items: center;
+    align-self: stretch;
+    border-radius: 0.37rem;
+    background: #FFF;
+    font-size: 0.65rem;
+    cursor: pointer;
+
+    span {
+        color: #000;
+        font-weight: 400;
+        font-size: 0.7rem;
+        font-style: normal;
+        line-height: 0.7rem;
+        margin-right: 0.2rem;
+    }
+`;
+
+export const DropdownMenu = styled.div`
+    // 드롭다운 컨테이너
+    position: absolute;
+    width: 8.8rem;
+    z-index: 10;
+    margin-top: 0.4rem;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 0.35rem;
+    align-self: stretch;
+    border-radius: 0.4375rem;
+    border: 0.7px solid #F0F0F0;
+    background: #FFF;
+    box-shadow: 0 3px 11px 0 rgba(0, 0, 0, 0.20);
+`;
+
+export const LeagueImage = styled.img`
+  width: 0.7rem;
+  height: 0.7rem;
+  margin-left: 1rem;
+`;
+
+export const LeagueName = styled.span`
+  margin-left: 0.7rem;
+  color: #000;
+  font-size: 0.62rem;
+  font-style: normal;
+  font-weight: 300;
+  line-height: 0.7rem;
+`;
+
+export const TabOption = styled.div`
+    // 드롭다운 각 리그
+    width: 100%;
+    color: #000;
+    font-size: 0.65rem;
+    padding: 0.3rem 0;
+    cursor: pointer;
+    align-items: center;
+
+    &:hover {
+        background-color: #F0F0F0;
+
+        ${LeagueName} {
+            font-weight: 400;
+        }
+    }
+
+    & + & {
+        border-top: 1px solid #F0F0F0;
+    }
+`;

--- a/src/pages/Community/community.jsx
+++ b/src/pages/Community/community.jsx
@@ -20,7 +20,7 @@ const Community = () => {
 
     const { selectedTeam } = useLeagueTeamStore();
 
-    const tabs = ["전체", "인기", selectedTeam?.nameKr || "응원팀"];
+    const tabs = ["전체", "인기", selectedTeam?.nameKr || ""];
 
     useEffect(() => {
         const fetchPosts = async () => {

--- a/src/pages/News/NewsItem.jsx
+++ b/src/pages/News/NewsItem.jsx
@@ -1,0 +1,49 @@
+import React from "react";
+import * as S from "./NewsItem.style";
+import {timeAgo} from "../../utils/timeUtils.js";
+import { truncateText } from "../../utils/textUtils.js";
+import ProfileSvg from "../../assets/profile.svg";
+
+const NewsItem = ({ title, content, ...props }) => {
+  return (
+      <S.NewsItemContainer>
+        <S.ContentWrapper>
+          <S.TextContentWrapper>
+            <S.TopSection>
+              <div>
+                <S.TeamBadgeWrapper>
+                  {props.team?.logoUrl && (
+                      <S.TeamIcon src={props.team.logoUrl} alt={`${props.team.nameKr} Logo`} />
+                  )}
+                <S.NewsBadge>{props.category}</S.NewsBadge>
+                </S.TeamBadgeWrapper>
+                <S.NewsTitle>{title}</S.NewsTitle>
+                <S.NewsContent>{truncateText(content)}</S.NewsContent>
+                <S.LeftInfo>
+                  <S.ProfileIcon src={props.user.profileImageUrl || ProfileSvg} alt="Profile" />
+                  <S.Nickname>{props.user.nickname}</S.Nickname>
+                  {/*<ProfileCheckIcon />*/}
+                  <S.StyledTime>{timeAgo(props.createdAt)}</S.StyledTime>
+                  <S.Divider>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="2" height="12" viewBox="0 0 2 12" fill="none">
+                      <path d="M1 0V12" stroke="#8C8C8C" strokeLinejoin="round"/>
+                    </svg>
+                  </S.Divider>
+                  <S.Reads>읽음 {props.views}</S.Reads>
+                </S.LeftInfo>
+              </div>
+              {props.thumbnailUrl && <S.Thumbnail src={props.thumbnailUrl} alt="Thumbnail" />}
+            </S.TopSection>
+            <S.RightInfo>
+              <S.GoodIcon />
+              <S.Likes>{props.likes}</S.Likes>
+              <S.CommentIcon />
+              <S.Comments>{props.replies}</S.Comments>
+            </S.RightInfo>
+          </S.TextContentWrapper>
+        </S.ContentWrapper>
+      </S.NewsItemContainer>
+  );
+};
+
+export default NewsItem;

--- a/src/pages/News/NewsItem.jsx
+++ b/src/pages/News/NewsItem.jsx
@@ -4,9 +4,9 @@ import {timeAgo} from "../../utils/timeUtils.js";
 import { truncateText } from "../../utils/textUtils.js";
 import ProfileSvg from "../../assets/profile.svg";
 
-const NewsItem = ({ title, content, ...props }) => {
+const NewsItem = ({ title, content, onClick, ...props }) => {
   return (
-      <S.NewsItemContainer>
+      <S.NewsItemContainer onClick={onClick}>
         <S.ContentWrapper>
           <S.TextContentWrapper>
             <S.TopSection>

--- a/src/pages/News/NewsItem.style.js
+++ b/src/pages/News/NewsItem.style.js
@@ -9,6 +9,7 @@ export const NewsItemContainer = styled.div`
   width: 100%;
   padding: 0.5rem 0 1rem 0;
   border-bottom: 0.0625rem solid #f0f0f0;
+  cursor: pointer;
 `;
 
 export const ContentWrapper = styled.div`

--- a/src/pages/News/NewsItem.style.js
+++ b/src/pages/News/NewsItem.style.js
@@ -1,0 +1,170 @@
+import styled from "styled-components";
+import { FaRegComment } from "react-icons/fa";
+import { PiSoccerBallFill } from "react-icons/pi";
+import { FaCheckCircle } from "react-icons/fa";
+
+export const NewsItemContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding: 0.5rem 0 1rem 0;
+  border-bottom: 0.0625rem solid #f0f0f0;
+`;
+
+export const ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center; 
+  gap: 1rem;
+  width: 100%;
+`;
+
+export const TextContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+`;
+
+export const NewsBadge = styled.div`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.1rem 0.5rem;
+  background-color: #f0f0f0;
+  border-radius: 1.25rem;
+  font-size: 0.53rem;
+  font-family: "Pretendard";
+  font-weight: 400;
+  color: #363636;
+  //margin-bottom: 0.5rem;
+`;
+
+export const NewsTitle = styled.h3`
+  color: black;
+  font-size: 0.9rem;
+  font-family: "Pretendard";
+  font-weight: 500;
+  margin: 0.45rem 0;
+`;
+
+export const NewsContent = styled.p`
+  color: black;
+  font-size: 0.583rem;
+  font-family: "Pretendard";
+  font-weight: normal;
+  line-height: 1rem;
+  margin-bottom: 0.8rem;
+`;
+
+export const Nickname = styled.span`
+  color: black;
+`;
+
+export const StyledTime = styled.span`
+  margin-left: 0.7rem;
+  color: #8c8c8c;
+`;
+
+export const Reads = styled.span`
+  color: #8c8c8c;
+`;
+
+export const Comments = styled.span`
+  color: #8f8f8f;
+`;
+
+export const Likes = styled.span`
+  color: #8f8f8f;
+`;
+
+export const Thumbnail = styled.img`
+  width: 7.2rem;
+  height: 4.67rem;
+  flex-shrink: 0;
+  border-radius: 0.36rem;
+  object-fit: cover; // 이미지 비율 유지를 위해 추가
+  margin: 1.3rem 0 0.5rem 1rem;
+`;
+
+export const ProfileIcon = styled.img`
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  object-fit: cover;
+  margin-right: 0.25rem;
+`;
+
+export const ProfileCheckIcon = styled(FaCheckCircle)`
+  width: 0.5rem;
+  height: 0.5rem;
+  margin-left: 0.25rem;
+  
+  & path:last-child {
+    fill: #8f8f8f; 
+`;
+
+export const Divider = styled.div`
+  width: 0;
+  height: 0.53rem;
+  stroke-width: 0.0625rem;
+  stroke: #8C8C8C;
+  margin: 0 0.36rem;
+  svg {
+    width: 0.1rem;
+    height: 0.53rem;
+  }
+`;
+
+export const LeftInfo = styled.div`
+  display: flex;
+  //gap: 0.5rem;
+  align-items: center; /* Center vertically */
+  justify-content: flex-start; /* Align to the left horizontally */
+  font-size: 0.65rem;
+  margin-top: 1rem;
+  font-weight: 400;
+`;
+
+export const RightInfo = styled.div`
+  display: flex;
+  gap: 0.3rem;
+  align-items: flex-end;
+  align-self: flex-end;
+  font-size: 0.63rem;
+  margin-top: 0.3rem;
+`;
+
+export const GoodIcon = styled(PiSoccerBallFill)`
+  width: 0.8rem;
+  height: 0.8rem;
+  color: #8f8f8f; 
+`;
+
+export const CommentIcon = styled(FaRegComment)`
+  width: 0.8rem;
+  height: 0.8rem;
+  margin-left: 0.2rem;
+  color: #8f8f8f;
+`;
+
+export const TopSection = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 100%;
+`;
+
+export const TeamIcon = styled.img`
+    width: 0.8rem;
+    height: 0.8rem;
+    object-fit: cover;
+    margin-right: 0.25rem;
+`;
+
+export const TeamBadgeWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  margin-bottom: 0.5rem;
+`;

--- a/src/pages/News/news.jsx
+++ b/src/pages/News/news.jsx
@@ -1,34 +1,56 @@
-import React, { useState } from "react";
-import { IoIosArrowDown } from "react-icons/io";
+import React, {useEffect, useState} from "react";
 import * as S from "./news.style";
-import { League } from "../../mocks/league.js";
-import {newsList} from "../../mocks/newsList.js";
-import NewsItem from "../../components/NewsList/NewsItem.jsx";
-import Pagination from "../../components/Pagination/pagination.jsx";
+import NewsItem from "./NewsItem.jsx";
+import LeagueDropdown from "../../components/League/leagueDropdown.jsx";
+import * as PS from "../../components/Pagination/pagination.style.js";
+import { GrFormNext, GrFormPrevious } from "react-icons/gr";
+import { useNavigate } from "react-router-dom";
+import { useLeagueTeamStore } from '../../store/useLeagueTeamStore';
+import { getNewsList } from "../../apis/domains/news/getNewsList";
 
 const News = () => {
-    const [activeTab, setActiveTab] = useState("전체");
-    const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-    const [activePage, setActivePage] = useState(1);
+    const [newsList, setNewsList] = useState([]);
     const [selectedLeague, setSelectedLeague] = useState("리그 선택");
+    const [activeTab, setActiveTab] = useState("전체");
+    const [activePage, setActivePage] = useState(1);
+    const [totalPages, setTotalPages] = useState(1);
+    const { selectedTeam } = useLeagueTeamStore();
+    const navigate = useNavigate();
 
-    const tabs = ["전체", "인기", "FC서울"];
-    const leagues = League;
-
-    const toggleDropdown = () => {
-        setIsDropdownOpen(!isDropdownOpen);
-    };
+    const tabs = ["전체", "인기", selectedTeam?.nameKr || "", selectedLeague];
 
     const handleTabClick = (tab) => {
         setActiveTab(tab);
+        setActivePage(1); // Reset to the first page when switching tabs
     };
 
-    const handleLeagueSelect = (league) => {
-        setSelectedLeague(league.krName);
-        setIsDropdownOpen(false);
-    };
+    useEffect(() => {
+        const fetchNews = async () => {
+            try {
+                const params = {
+                    size: 10,
+                    page: activePage,
+                    order: activeTab === "인기" ? "hot" : "recent",
+                    team: activeTab === selectedTeam?.nameKr ? selectedTeam.pk : undefined,
+                    league: selectedLeague !== "리그 선택" ? selectedLeague : undefined,
+                };
 
-    const totalPages = 10;
+                const response = await getNewsList(params);
+
+                if (response.data) {
+                    setNewsList(response.data);
+                    setTotalPages(response.meta.totalPages || 1);
+                } else {
+                    setNewsList([]);
+                    setTotalPages(1);
+                }
+            } catch (error) {
+                console.error("뉴스를 불러오는 데 실패했습니다:", error);
+            }
+        };
+
+        fetchNews();
+    }, [activeTab, activePage, selectedLeague, selectedTeam]);
 
     return (
         <S.Container>
@@ -44,23 +66,10 @@ const News = () => {
                         </S.TabButton>
                     ))}
 
-                    <S.DropdownContainer>
-                        <S.TabSelector onClick={toggleDropdown} selected={isDropdownOpen}>
-                            <span>{selectedLeague}</span>
-                            <IoIosArrowDown size="0.7rem" color="#8F8F8F" />
-                        </S.TabSelector>
-
-                        {isDropdownOpen && (
-                            <S.DropdownMenu>
-                                {leagues.map(league => (
-                                    <S.TabOption key={league.pk} onClick={() => handleLeagueSelect(league)}>
-                                        <S.LeagueImage src={league.logoUrl} alt={league.krName} />
-                                        <S.LeagueName>{league.krName}</S.LeagueName>
-                                    </S.TabOption>
-                                ))}
-                            </S.DropdownMenu>
-                        )}
-                    </S.DropdownContainer>
+                    <LeagueDropdown
+                        selectedLeague={selectedLeague}
+                        setSelectedLeague={setSelectedLeague}
+                    />
                 </S.NavContainer>
 
                 <S.Divider>
@@ -70,12 +79,30 @@ const News = () => {
                 </S.Divider>
 
                 <S.NewsList>
-                    {newsList.map((item, index) => (
-                        <NewsItem key={index} {...item} />
+                    {newsList.map((item) => (
+                        <NewsItem key={item.pk} {...item} onClick={() => navigate(`/news/${item.pk}`)}/>
                     ))}
                 </S.NewsList>
 
-                <Pagination activePage={activePage} setActivePage={setActivePage} totalPages={totalPages} />
+                <PS.PaginationWrapper>
+                    <PS.NavButton onClick={() => activePage > 1 && setActivePage(prev => prev - 1)}
+                                 disabled={activePage === 1}>
+                        <GrFormPrevious /> 이전
+                    </PS.NavButton>
+                    {Array.from({ length: totalPages }, (_, i) => (
+                        <PS.PageButton
+                            key={i + 1}
+                            active={activePage === i + 1}
+                            onClick={() => setActivePage(i + 1)}
+                        >
+                            {i + 1}
+                        </PS.PageButton>
+                    ))}
+                    <PS.NavButton onClick={() => activePage < totalPages && setActivePage(prev => prev + 1)}
+                                 disabled={activePage === totalPages}>
+                        다음 <GrFormNext />
+                    </PS.NavButton>
+                </PS.PaginationWrapper>
             </S.NewsContainer>
         </S.Container>
     );

--- a/src/pages/News/news.jsx
+++ b/src/pages/News/news.jsx
@@ -95,7 +95,10 @@ const News = () => {
 
                 <S.NewsList>
                     {newsList.map((item) => (
-                        <NewsItem key={item.pk} {...item} onClick={() => navigate(`/news/${item.pk}`)}/>
+                        <NewsItem key={item.pk} {...item} onClick={() => {
+                            console.log(`Navigating to /news/${item.pk}`);
+                            navigate(`/news/${item.pk}`)
+                        }}/>
                     ))}
                 </S.NewsList>
 

--- a/src/pages/News/news.jsx
+++ b/src/pages/News/news.jsx
@@ -10,14 +10,19 @@ import { getNewsList } from "../../apis/domains/news/getNewsList";
 
 const News = () => {
     const [newsList, setNewsList] = useState([]);
-    const [selectedLeague, setSelectedLeague] = useState("리그 선택");
+    const [selectedLeague, setSelectedLeague] = useState(null);
     const [activeTab, setActiveTab] = useState("전체");
     const [activePage, setActivePage] = useState(1);
     const [totalPages, setTotalPages] = useState(1);
     const { selectedTeam } = useLeagueTeamStore();
     const navigate = useNavigate();
+    const leaguePk = selectedLeague?.pk || undefined;
 
-    const tabs = ["전체", "인기", selectedTeam?.nameKr || "", selectedLeague];
+    const tabs = [
+        { type: "text", label: "전체", value: "전체" },
+        { type: "text", label: "인기", value: "인기" },
+        selectedTeam?.nameKr && { type: "text", label: selectedTeam.nameKr, value: selectedTeam.nameKr },
+    ].filter(Boolean);
 
     const handleTabClick = (tab) => {
         setActiveTab(tab);
@@ -32,7 +37,7 @@ const News = () => {
                     page: activePage,
                     order: activeTab === "인기" ? "hot" : "recent",
                     team: activeTab === selectedTeam?.nameKr ? selectedTeam.pk : undefined,
-                    league: selectedLeague !== "리그 선택" ? selectedLeague : undefined,
+                    league: leaguePk,
                 };
 
                 const response = await getNewsList(params);
@@ -56,25 +61,35 @@ const News = () => {
         <S.Container>
             <S.NewsContainer>
                 <S.NavContainer>
-                    {tabs.map(tab => (
+                    {tabs.map((tab, index) => (
                         <S.TabButton
-                            key={tab}
-                            isActive={activeTab === tab}
-                            onClick={() => handleTabClick(tab)}
+                            key={tab.value}
+                            isActive={activeTab === tab.value}
+                            onClick={() => handleTabClick(tab.value)}
                         >
-                            {tab}
+                            {tab.label}
                         </S.TabButton>
                     ))}
 
                     <LeagueDropdown
                         selectedLeague={selectedLeague}
-                        setSelectedLeague={setSelectedLeague}
+                        setSelectedLeague={(league) => {
+                            setSelectedLeague(league);
+                            setActiveTab(league.nameKr);
+                            setActivePage(1);
+                        }}
+                        activeTab={activeTab}
                     />
                 </S.NavContainer>
 
                 <S.Divider>
-                    {tabs.indexOf(activeTab) >= 0 && (
-                        <S.ActiveIndicator left={`${tabs.indexOf(activeTab) * 3 + 0.7}rem`} />
+                    {tabs.map((tab, idx) =>
+                            tab.value === activeTab && (
+                                <S.ActiveIndicator key={tab.value} left={`calc(${idx} * 3rem + 0.7rem)`} />
+                            )
+                    )}
+                    {selectedLeague?.nameKr === activeTab && (
+                        <S.ActiveIndicator left={`calc(${tabs.length} * 3rem + 1rem)`} />
                     )}
                 </S.Divider>
 

--- a/src/pages/News/news.style.js
+++ b/src/pages/News/news.style.js
@@ -37,89 +37,9 @@ export const TabButton = styled.div`
   cursor: pointer;
 `;
 
-export const DropdownContainer = styled.div`
-  position: relative;
-`;
-
-export const TabSelector = styled.div`
-    // 리그 선택 탭
-    display: flex;
-    width: auto;
-    justify-content: space-between;
-    align-items: center;
-    align-self: stretch;
-    border-radius: 0.37rem;
-    background: #FFF;
-    font-size: 0.65rem;
-    cursor: pointer;
-
-    span {
-        color: #000;
-        font-weight: 400;
-        font-size: 0.7rem;
-        font-style: normal;
-        line-height: 0.7rem;
-        margin-right: 0.2rem;
-    }
-`;
-
-export const DropdownMenu = styled.div`
-    // 드롭다운 컨테이너
-    position: absolute;
-    width: 8.8rem;
-    z-index: 10;
-    margin-top: 0.4rem;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    gap: 0.35rem;
-    align-self: stretch;
-    border-radius: 0.4375rem;
-    border: 0.7px solid #F0F0F0;
-    background: #FFF;
-    box-shadow: 0 3px 11px 0 rgba(0, 0, 0, 0.20);
-`;
-
-export const LeagueImage = styled.img`
-  width: 0.7rem;
-  height: 0.7rem;
-  margin-left: 1rem;
-`;
-
-export const LeagueName = styled.span`
-  margin-left: 0.7rem;
-  color: #000;
-  font-size: 0.62rem;
-  font-style: normal;
-  font-weight: 300;
-  line-height: 0.7rem;
-`;
-
-export const TabOption = styled.div`
-    // 드롭다운 각 리그
-    width: 100%;
-    color: #000;
-    font-size: 0.65rem;
-    padding: 0.3rem 0;
-    cursor: pointer;
-    align-items: center;
-
-    &:hover {
-        background-color: #F0F0F0;
-
-        ${LeagueName} {
-            font-weight: 400;
-        }
-    }
-
-    & + & {
-        border-top: 1px solid #F0F0F0;
-    }
-`;
-
 export const Divider = styled.div`
   width: 100%;
-  height: 0rem;
+  height: 0;
   flex-shrink: 0;
   stroke-width: 1px;
   stroke: #DCDCDC;

--- a/src/pages/News/news.style.js
+++ b/src/pages/News/news.style.js
@@ -51,7 +51,7 @@ export const Divider = styled.div`
 export const ActiveIndicator = styled.div`
     position: absolute;
     top: -1px;
-    width: 1.85rem;
+    width: 2rem;
     height: 0;
     stroke-width: 2px;
     stroke: #C00C0B;

--- a/src/pages/Signup/signup.jsx
+++ b/src/pages/Signup/signup.jsx
@@ -16,8 +16,6 @@ import { useLeagueTeamStore } from '../../store/useLeagueTeamStore';
 const Signup = () => {
   const [nickname, setNickname] = useState("");
   const [nicknameError, setNicknameError] = useState("");
-  // const [selectedLeague, setSelectedLeague] = useState("");
-  // const [selectedTeam, setSelectedTeam] = useState("");
   const [teamOptions, setTeamOptions] = useState([]);
   const [isLeagueDropdownOpen, setIsLeagueDropdownOpen] = useState(false);
   const [isTeamDropdownOpen, setIsTeamDropdownOpen] = useState(false);

--- a/src/utils/textUtils.js
+++ b/src/utils/textUtils.js
@@ -1,0 +1,6 @@
+export const truncateText = (text, maxLength = 117) => {
+    if (text.length > maxLength) {
+        return text.slice(0, maxLength) + "...";
+    }
+    return text;
+};


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #64 

## ✨ 작업 개요
> 작업 내용을 간략하게 작성해주세요.
- 뉴스 리스트 조회 API를 연결했습니다.
- 리그 드롭다운을 컴포넌트로 분리했습니다.

## 📷 이미지 첨부 (선택)
- 작업 결과를 확인할 수 있는 이미지나 GIF를 첨부해주세요.  
- UI 변경, API 응답 샘플, 테스트 결과 등이 포함되면 좋아요!
<img width="1582" alt="image" src="https://github.com/user-attachments/assets/357ca07d-7c71-4c24-9321-8ef56af72535" />
<img width="1582" alt="image" src="https://github.com/user-attachments/assets/5165c2bf-4feb-441a-8192-38ccbff57345" />


## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
1. 탭 강조 효과인 빨간 선의 길이가 조금 짧은.. 이슈가 있습니다
2. 뉴스 리스트에서 특정 글 선택 시 news/:newsId로 이동을 하긴 하는데... UI가 클럽 커뮤니티 상세 UI입니다ㅜ
