### PR TITLE
Refactor: 탑 뉴스 클릭이벤트 및 게시글 리스트 UI 개선

### DIFF
--- a/src/components/CommunityBoard/CommunityBoard.style.js
+++ b/src/components/CommunityBoard/CommunityBoard.style.js
@@ -147,16 +147,9 @@ export const PostTitle = styled.div`
     min-width: 0;
     max-width: 100%;
   flex: 4;
-  font-size: 0.65rem;
-  font-weight: 500;
-  padding-left: 0.5rem;
+  font-size: 0.6rem;
+  font-weight: 400;
   color: black;
-  display: -webkit-box;
-  -webkit-line-clamp: 2; /* 최대 2줄까지 표시 */
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  word-break: break-word;
 
   img {
     width: 0.6rem;

--- a/src/components/CommunityBoard/CommunityBoard.style.js
+++ b/src/components/CommunityBoard/CommunityBoard.style.js
@@ -1,7 +1,6 @@
 import styled from "styled-components";
 import MoreSvg from "../../assets/more.png";
 import ProfileSvg from "../../assets/profile.svg";
-import { PiSoccerBallFill } from "react-icons/pi";
 
 export const CommunityBoardContainer = styled.div`
   display: flex;
@@ -76,34 +75,34 @@ export const TableHeader = styled.div`
   font-style: normal;
   font-weight: 400;
   line-height: 1rem; /* 138.462% */
-  
+
   .title {
-    flex: 5;
-    padding-left: 0.5rem;
+    flex: 6;
+    text-align: center;
   }
-  
+
   .author {
-    flex: 2;
+    flex: 2.14;
     text-align: center;
   }
-  
   .date {
-    flex: 2;
+    flex: 1.5;
     text-align: center;
   }
-  
-  .likes {
-    flex: 1;
-    text-align: center;
-  }
-  
+
   .views {
     flex: 1;
     text-align: center;
   }
-`;
 
-export const TableHeaderItem = styled.div``;
+  .likes {
+    flex: 1;
+    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+`;
 
 export const PostsWrapper = styled.div`
   display: flex;
@@ -118,7 +117,7 @@ export const PostItem = styled.div`
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  padding: 0.75rem 0;
+  padding: 0.55rem 0;
   border-bottom: 0.0625rem solid #f0f0f0;
   
   &:last-child {
@@ -127,60 +126,81 @@ export const PostItem = styled.div`
 `;
 
 export const PostTitle = styled.div`
-  flex: 5;
-  font-size: 0.65rem;
-  font-weight: 500;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  padding-left: 0.5rem;
+  flex: 5.5;
+  font-size: 0.6rem;
+  font-weight: 350;
   color: black;
-  display: flex;
-  align-items: center;
+  padding-left: 0.5rem;
+  padding-right: 1.25rem;
+  min-width: 0;
 
-  img {
-    width: 0.6rem;
-    height: 0.6rem;
-    margin-left: 0.25rem;
+  .clamp {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    word-break: break-word;
+    white-space: normal;
+    min-width: 0;
+    max-width: 100%;
   }
 
   .reply-count {
     color: #000;
     font-weight: normal;
-    margin-left: 0.25rem
+    margin-left: 0.15rem;
+    white-space: nowrap;
   }
 `;
 
+
+
 export const PostAuthor = styled.div`
-  flex: 2;
-  font-size: 0.6rem;
+  flex: 2.14;
+  font-size: 0.55rem;
   color: #000;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 0.25rem;
   font-weight: 350;
+
+  img {
+    width: 0.85rem;
+    height: 0.85rem;
+    border-radius: 50%;
+    object-fit: cover;
+  }
 `;
 
 export const PostDate = styled.div`
-  flex: 2;
-  font-size: 0.6rem;
+  flex: 1.5;
+  font-size: 0.55rem;
   color: #8c8c8c;
   text-align: center;
 `;
 
 export const PostLikes = styled.div`
+  width: auto;
   flex: 1;
-  font-size: 0.6rem;
+  min-width: 2rem;
+  font-size: 0.55rem;
   color: #8f8f8f;
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 `;
 
 export const PostViews = styled.div`
+  width: auto;
   flex: 1;
-  font-size: 0.6rem;
+  min-width: 2rem;
+  font-size: 0.55rem;
   color: #8f8f8f;
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 `;
 
 export const ProfileIcon = styled.img.attrs({
@@ -190,12 +210,6 @@ export const ProfileIcon = styled.img.attrs({
   width: 0.6rem;
   height: 0.6rem;
   margin-right: 0.3rem;
-`;
-
-export const GoodIcon = styled(PiSoccerBallFill)`
-  width: 0.8rem;
-  height: 0.8rem;
-  color: #8f8f8f; 
 `;
 
 export const TableHeaderSeparator = styled.div`

--- a/src/components/CommunityBoard/CommunityBoard.style.js
+++ b/src/components/CommunityBoard/CommunityBoard.style.js
@@ -27,7 +27,7 @@ export const CommunityHeader = styled.div`
   font-weight: 500;
   line-height: 0.85rem;
   color: black;
-  
+
   .title {
     display: flex;
     align-items: center;
@@ -48,9 +48,9 @@ export const MoreLink = styled.a`
   align-items: center;
   gap: 0.25rem;
   text-decoration: none;
-  
+
   &:hover {
-  text-decoration: underline;
+    text-decoration: underline;
   }
 `;
 
@@ -121,7 +121,7 @@ export const PostItem = styled.div`
   padding: 0.55rem 0;
   border-bottom: 0.0625rem solid #f0f0f0;
   cursor: pointer;
-  
+
   &:last-child {
     border-bottom: none;
   }
@@ -146,23 +146,23 @@ export const PostTitle = styled.div`
     white-space: normal;
     min-width: 0;
     max-width: 100%;
-  flex: 4;
-  font-size: 0.6rem;
-  font-weight: 400;
-  color: black;
+    flex: 4;
+    font-size: 0.6rem;
+    font-weight: 400;
+    color: black;
 
-  img {
-    width: 0.6rem;
-    height: 0.6rem;
-    margin-left: 0.25rem;
-  }
+    img {
+      width: 0.6rem;
+      height: 0.6rem;
+      margin-left: 0.25rem;
+    }
 
-  .reply-count {
-    color: #000;
-    font-weight: normal;
-    margin-left: 0.15rem;
-    white-space: nowrap;
-  }
+    .reply-count {
+      color: #000;
+      font-weight: normal;
+      margin-left: 0.15rem;
+      white-space: nowrap;
+    }
 `;
 
 export const PostAuthor = styled.div`

--- a/src/components/CommunityBoard/communityBoard.jsx
+++ b/src/components/CommunityBoard/communityBoard.jsx
@@ -13,10 +13,11 @@ import {
   PostViews,
   PostLikes,
   TableHeader,
-  ProfileIcon,
 } from "./CommunityBoard.style";
 import {Link, useNavigate} from "react-router-dom";
 import GoodIcon from "../../assets/good.svg";
+import { getBoardHome } from "../../apis/domains/main/getBoardHome";
+import {formatDate} from "../../utils/formatDate.js";
 
 const CommunityBoard = ({ type }) => {
   const [posts, setPosts] = useState([]);
@@ -82,15 +83,15 @@ const CommunityBoard = ({ type }) => {
                 src={post.user.profileImageUrl}
                 alt="프로필"
                 style={{
-                  width: '0.6rem',
-                  height: '0.6rem',
+                  width: '0.78rem',
+                  height: '0.78rem',
                   borderRadius: '50%',
                   marginRight: '0.3rem'
                 }}
               />
               {post.user.nickname}
             </PostAuthor>
-            <PostDate>{new Date(post.createdAt).toLocaleDateString()}</PostDate>
+            <PostDate>{formatDate(post.createdAt)}</PostDate>
             <PostViews>{post.views}</PostViews>
             <PostLikes>{post.likes}</PostLikes>
           </PostItem>

--- a/src/components/CommunityBoard/communityBoard.jsx
+++ b/src/components/CommunityBoard/communityBoard.jsx
@@ -86,7 +86,7 @@ const CommunityBoard = ({ type }) => {
                   width: '0.78rem',
                   height: '0.78rem',
                   borderRadius: '50%',
-                  marginRight: '0.3rem'
+                  marginRight: '0.1rem'
                 }}
               />
               {post.user.nickname}

--- a/src/components/CommunityBoard/communityBoard.jsx
+++ b/src/components/CommunityBoard/communityBoard.jsx
@@ -18,6 +18,7 @@ import {Link, useNavigate} from "react-router-dom";
 import GoodIcon from "../../assets/good.svg";
 import { getBoardHome } from "../../apis/domains/main/getBoardHome";
 import {formatDate} from "../../utils/formatDate.js";
+import NoData from "../../components/NoData/noData.jsx";
 
 const CommunityBoard = ({ type }) => {
   const [posts, setPosts] = useState([]);
@@ -68,34 +69,37 @@ const CommunityBoard = ({ type }) => {
         </div>
       </TableHeader>
       <PostsWrapper>
-        {posts.map((post) => (
-          <PostItem
-            key={post.pk}
-            onClick={() => navigate(`/community/${post.pk}`)}
-          >
-            <PostTitle>
-              {post.title}
-              {/*{post.hasImage && <img src={ImageIcon} alt="이미지" />}*/}
-              {post.replies > 0 && <span className="reply-count">({post.replies})</span>}
-            </PostTitle>
-            <PostAuthor>
-              <img
-                src={post.user.profileImageUrl}
-                alt="프로필"
-                style={{
-                  width: '0.78rem',
-                  height: '0.78rem',
-                  borderRadius: '50%',
-                  marginRight: '0.1rem'
-                }}
-              />
-              {post.user.nickname}
-            </PostAuthor>
-            <PostDate>{formatDate(post.createdAt)}</PostDate>
-            <PostViews>{post.views}</PostViews>
-            <PostLikes>{post.likes}</PostLikes>
-          </PostItem>
-        ))}
+        {posts.length === 0 ? (
+            <NoData />
+        ) : (
+            posts.map((post) => (
+                <PostItem
+                    key={post.pk}
+                    onClick={() => navigate(`/community/${post.pk}`)}
+                >
+                  <PostTitle>
+                    {post.title}
+                    {post.replies > 0 && <span className="reply-count">({post.replies})</span>}
+                  </PostTitle>
+                  <PostAuthor>
+                    <img
+                        src={post.user.profileImageUrl}
+                        alt="프로필"
+                        style={{
+                          width: '0.78rem',
+                          height: '0.78rem',
+                          borderRadius: '50%',
+                          marginRight: '0.1rem'
+                        }}
+                    />
+                    {post.user.nickname}
+                  </PostAuthor>
+                  <PostDate>{formatDate(post.createdAt)}</PostDate>
+                  <PostViews>{post.views}</PostViews>
+                  <PostLikes>{post.likes}</PostLikes>
+                </PostItem>
+            ))
+        )}
       </PostsWrapper>
     </CommunityBoardContainer>
   );

--- a/src/components/CommunityBoard/communityBoard.jsx
+++ b/src/components/CommunityBoard/communityBoard.jsx
@@ -14,10 +14,9 @@ import {
   PostLikes,
   TableHeader,
   ProfileIcon,
-  GoodIcon,
 } from "./CommunityBoard.style";
-import ImageIcon from "../../assets/image.svg";
 import {Link} from "react-router-dom";
+import GoodIcon from "../../assets/good.svg";
 
 const CommunityBoard = ({ type }) => {
   const initialPosts = [
@@ -64,7 +63,7 @@ const CommunityBoard = ({ type }) => {
         <div className="title">
           {type === "communityDetail" ? "함께 볼 만한 게시글" : "클럽 커뮤니티"}
         </div>
-        <MoreLink as={Link} to="/community">
+        <MoreLink to="/community">
           더 보기
           <MoreIcon />
         </MoreLink>
@@ -75,14 +74,17 @@ const CommunityBoard = ({ type }) => {
         <div className="author">글쓴이</div>
         <div className="date">날짜</div>
         <div className="views">조회</div>
-        <div className="likes"><GoodIcon/>킥</div>
+        <div className="likes">
+          <img src={GoodIcon} alt="좋아요" style={{ width: '0.7rem', height: '0.7rem', marginRight: '0.25rem' }} />
+          킥
+        </div>
       </TableHeader>
       <PostsWrapper>
         {initialPosts.map((post, index) => (
           <PostItem key={index}>
             <PostTitle>
               {post.title} 
-              {post.profileImageUrl && <img src={ImageIcon} alt="이미지 있음" />} 
+              {/*{post.profileImageUrl && <img src={ImageIcon} alt="이미지 있음" />} */}
               <span className="reply-count">({post.replyCount})</span>
             </PostTitle>
             <PostAuthor>

--- a/src/components/CommunityBoard/communityBoard.jsx
+++ b/src/components/CommunityBoard/communityBoard.jsx
@@ -78,8 +78,10 @@ const CommunityBoard = ({ type }) => {
                     onClick={() => navigate(`/community/${post.pk}`)}
                 >
                   <PostTitle>
-                    {post.title}
-                    {post.replies > 0 && <span className="reply-count">({post.replies})</span>}
+                    <span className="clamp">
+                      {post.title}
+                      {post.replies > 0 && <span className="reply-count">({post.replies})</span>}
+                    </span>
                   </PostTitle>
                   <PostAuthor>
                     <img

--- a/src/components/CommunityBoard/communityBoard.jsx
+++ b/src/components/CommunityBoard/communityBoard.jsx
@@ -74,9 +74,10 @@ const CommunityBoard = ({ type }) => {
             onClick={() => navigate(`/community/${post.pk}`)}
           >
             <PostTitle>
-              {post.title}
-              {/*{post.hasImage && <img src={ImageIcon} alt="이미지" />}*/}
-              {post.replies > 0 && <span className="reply-count">({post.replies})</span>}
+              <span className="clamp">
+                {post.title}
+                {post.replies > 0 && <span className="reply-count">({post.replies})</span>}
+              </span>
             </PostTitle>
             <PostAuthor>
               <img

--- a/src/components/NewsList/NewsItem.jsx
+++ b/src/components/NewsList/NewsItem.jsx
@@ -26,12 +26,7 @@ import {
 } from "./NewsItem.style";
 import {timeAgo} from "../../utils/timeUtils.js";
 import GoodIcon from "../../assets/good.svg";
-
-const stripHtml = (html) => {
-  const tmp = document.createElement("DIV");
-  tmp.innerHTML = html;
-  return tmp.textContent || tmp.innerText || "";
-};
+import {stripHtml} from "../../utils/stripHtml.js";
 
 const NewsItem = ({ pk, title, content, thumbnailUrl, user, createdAt, views, likes, replies, category }) => {
   const navigate = useNavigate();

--- a/src/components/NewsList/NewsItem.jsx
+++ b/src/components/NewsList/NewsItem.jsx
@@ -16,7 +16,6 @@ import {
   Thumbnail,
   ProfileIcon,
   ProfileCheckIcon,
-  GoodIcon,
   CommentIcon,
   Divider,
   ContentWrapper,
@@ -26,6 +25,7 @@ import {
   TopSection
 } from "./NewsItem.style";
 import {timeAgo} from "../../utils/timeUtils.js";
+import GoodIcon from "../../assets/good.svg";
 
 const stripHtml = (html) => {
   const tmp = document.createElement("DIV");
@@ -69,7 +69,7 @@ const NewsItem = ({ pk, title, content, thumbnailUrl, user, createdAt, views, li
               {thumbnailUrl && <Thumbnail src={thumbnailUrl} alt="Thumbnail" />}
             </TopSection>
             <RightInfo>
-              <GoodIcon />
+              <img src={GoodIcon} alt="좋아요" style={{ width: '0.7rem', height: '0.7rem', marginRight: '0.1rem' }} />
               <Likes>{likes}</Likes>
               <CommentIcon />
               <Comments>{replies}</Comments>

--- a/src/components/NewsList/newsList.jsx
+++ b/src/components/NewsList/newsList.jsx
@@ -1,88 +1,71 @@
-import React, { useState, useEffect } from "react";
-import { NewsListContainer, NewsHeader, MoreLink, MoreIcon, NewsItemsWrapper } from "./NewsList.style";
+import React, { useEffect, useState } from "react";
+import {
+  NewsListContainer,
+  NewsHeader,
+  MoreLink,
+  MoreIcon,
+  NewsItemsWrapper,
+} from "./NewsList.style";
 import NewsItem from "./NewsItem";
 import { Link } from "react-router-dom";
-import axiosInstance from "../../apis/axios-instance";
-import { getUserInfo } from "../../apis/domains/main/getUserInfo";
-import { useLeagueTeamStore } from "../../store/useLeagueTeamStore"; // 추가된 import
 import { getHomeNewsList } from "../../apis/domains/main/getHomeNewsList.js";
+import { useLeagueTeamStore } from "../../store/useLeagueTeamStore";
+import NoData from "../../components/NoData/noData.jsx";
 
 const NewsList = ({ type }) => {
   const [newsItems, setNewsItems] = useState([]);
-  const [userInfo, setUserInfo] = useState({ isLoggedIn: false });
   const [loading, setLoading] = useState(true);
-  const { selectedTeam } = useLeagueTeamStore(); // Zustand 스토어에서 선택된 팀 정보 가져오기
+
+  const { selectedTeam } = useLeagueTeamStore();
 
   useEffect(() => {
-    const fetchData = async () => {
+    const fetchNews = async () => {
       setLoading(true);
-
       try {
-        const userInfoResponse = await getUserInfo();
-        setUserInfo(userInfoResponse);
-
-        const newsItems = await getHomeNewsList(type || ' ');
-        setNewsItems(Array.isArray(newsItems) ? newsItems : []);
+        const result = await getHomeNewsList(type || " ");
+        setNewsItems(Array.isArray(result) ? result : []);
       } catch (error) {
-        console.error("데이터 로딩 실패:", error);
+        console.error("뉴스 데이터 로딩 실패:", error);
         setNewsItems([]);
       } finally {
         setLoading(false);
       }
     };
 
-    fetchData();
+    fetchNews();
   }, [type]);
 
-  // 헤더 텍스트 생성 함수
   const getHeaderText = () => {
-    if (type === "other") {
-      return "함께 볼 만한 뉴스";
-    }
-
-    if (selectedTeam && selectedTeam.nameKr) {
+    if (type === "other") return "함께 볼 만한 뉴스";
+    if (selectedTeam?.nameKr)
       return (
           <>
-            함께 볼 만한 <span style={{ color: 'red' }}>{selectedTeam.nameKr}</span> 뉴스
+            함께 볼 만한 <span style={{ color: "red" }}>{selectedTeam.nameKr}</span> 뉴스
           </>
       );
-    }
-
     return "함께 볼 만한 뉴스";
   };
 
-  if (loading) {
-    return <div>로딩 중...</div>;
-  }
+  if (loading) return <div>로딩 중...</div>;
 
   return (
-    <NewsListContainer>
-      <NewsHeader>
-        <div className="title">
-          {getHeaderText()}
-        </div>
-        <MoreLink as={Link} to="/news">
-          더보기 <MoreIcon />
-        </MoreLink>
-      </NewsHeader>
-      <NewsItemsWrapper>
-        {newsItems.map((item, index) => (
-          <NewsItem
-            key={index}
-            pk={item.pk}
-            title={item.title}
-            content={item.content}
-            thumbnailUrl={item.thumbnailUrl}
-            user={item.user}
-            createdAt={item.createdAt}
-            views={item.views}
-            likes={item.likes}
-            replies={item.replies}
-            category={item.category}
-          />
-        ))}
-      </NewsItemsWrapper>
-    </NewsListContainer>
+      <NewsListContainer>
+        <NewsHeader>
+          <div className="title">{getHeaderText()}</div>
+          <MoreLink as={Link} to="/news">
+            더보기 <MoreIcon />
+          </MoreLink>
+        </NewsHeader>
+        <NewsItemsWrapper>
+          {newsItems.length === 0 ? (
+              <NoData />
+          ) : (
+              newsItems.map((item) => (
+                  <NewsItem key={item.pk} {...item} />
+              ))
+          )}
+        </NewsItemsWrapper>
+      </NewsListContainer>
   );
 };
 

--- a/src/components/NewsList/newsList.jsx
+++ b/src/components/NewsList/newsList.jsx
@@ -5,6 +5,7 @@ import { Link } from "react-router-dom";
 import axiosInstance from "../../apis/axios-instance";
 import { getUserInfo } from "../../apis/domains/main/getUserInfo";
 import { useLeagueTeamStore } from "../../store/useLeagueTeamStore"; // 추가된 import
+import { getHomeNewsList } from "../../apis/domains/main/getHomeNewsList.js";
 
 const NewsList = ({ type }) => {
   const [newsItems, setNewsItems] = useState([]);
@@ -14,22 +15,18 @@ const NewsList = ({ type }) => {
 
   useEffect(() => {
     const fetchData = async () => {
+      setLoading(true);
+
       try {
-        // 사용자 정보 가져오기
         const userInfoResponse = await getUserInfo();
         setUserInfo(userInfoResponse);
 
-        // 뉴스 데이터 가져오기
-        const response = await axiosInstance.get('/api/news/home', {
-          params: { type: type || ' ' }
-        });
-
-        if (response.code === "GET_SUCCESS") {
-          setNewsItems(response.data);
-        }
-        setLoading(false);
+        const newsItems = await getHomeNewsList(type || ' ');
+        setNewsItems(Array.isArray(newsItems) ? newsItems : []);
       } catch (error) {
         console.error("데이터 로딩 실패:", error);
+        setNewsItems([]);
+      } finally {
         setLoading(false);
       }
     };
@@ -39,23 +36,18 @@ const NewsList = ({ type }) => {
 
   // 헤더 텍스트 생성 함수
   const getHeaderText = () => {
-    // 선택된 팀 정보가 있는 경우 (Zustand 스토어 사용)
+    if (type === "other") {
+      return "함께 볼 만한 뉴스";
+    }
+
     if (selectedTeam && selectedTeam.nameKr) {
       return (
-        <>
-          함께 볼 만한 <span style={{ color: 'red' }}>{selectedTeam.nameKr}</span> 뉴스
-        </>
+          <>
+            함께 볼 만한 <span style={{ color: 'red' }}>{selectedTeam.nameKr}</span> 뉴스
+          </>
       );
     }
-    // 로그인 상태이고 응원팀 정보가 있는 경우 (기존 방식 백업)
-    else if (userInfo.isLoggedIn && userInfo.userData?.favoriteTeam) {
-      return (
-        <>
-          함께 볼 만한 <span style={{ color: 'red' }}>{userInfo.userData.favoriteTeam.nameKr}</span> 뉴스
-        </>
-      );
-    }
-    // 로그인 상태가 아니거나 응원팀 정보가 없는 경우
+
     return "함께 볼 만한 뉴스";
   };
 

--- a/src/components/Profile/profile.style.js
+++ b/src/components/Profile/profile.style.js
@@ -70,8 +70,8 @@ export const ProfileInfo = styled.div`
 `;
 
 export const ProfileImage = styled.img`
-    width: 2.8rem;
-    height: 2.8rem;
+    width: 2.5rem;
+    height: 2.5rem;
     flex-shrink: 0;
     border-radius: 50%;
     object-fit: cover;
@@ -96,7 +96,7 @@ export const Username = styled.div`
     gap: 0.2rem;
     color: #000;
     font-family: Pretendard;
-    font-size: 0.94rem;
+    font-size: 0.8rem;
     font-weight: 600;
     line-height: 1.13rem;
     margin: 0;

--- a/src/components/TopNews/topNews.jsx
+++ b/src/components/TopNews/topNews.jsx
@@ -1,11 +1,17 @@
 import React, {useEffect, useState} from "react";
 import {ContainerTitle, TopNewsContainer, TNews, NewsImage, NewsTitle} from "./topNews.style.js";
 import {getTopNews} from "../../apis/domains/news/getTopNews.js";
+import {useNavigate} from "react-router-dom";
 
 const TopNews = () => {
     const [newsItems, setNewsItems] = useState([]);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState(null);
+    const navigate = useNavigate();
+
+    const handleClick = (pk) => {
+        navigate(`/news/${pk}`);
+    };
 
     useEffect(() => {
         const fetchTopNews = async () => {
@@ -48,7 +54,11 @@ const TopNews = () => {
             <TopNewsContainer>
                 <ContainerTitle>많이 본 뉴스 TOP 5</ContainerTitle>
                 {newsItems.slice(0, 5).map((news, index) => (
-                    <TNews key={news.pk || index}>
+                    <TNews
+                        key={news.pk || index}
+                        onClick={() => handleClick(news.pk)}
+                        style={{ cursor: 'pointer' }}
+                    >
                         <NewsImage
                             src={news.thumbnailUrl}
                         />

--- a/src/pages/Community/community.jsx
+++ b/src/pages/Community/community.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import {
-    NewsContainer,  NavContainer, TabButton, Divider, ActiveIndicator, PostAuthor, PostDate,
-    PostItem, PostLikes, PostsWrapper, PostTitle, PostViews, TableHeader
+    NewsContainer, Tab, TabContainer, TableHeader, PostAuthor, PostDate,
+    PostItem, PostLikes, PostsWrapper, PostTitle, PostViews
 } from "./community.style.js";
 import GoodIcon from "../../assets/good_black.svg";
 import ProfileIcon from "../../assets/profile.svg";
@@ -21,11 +21,7 @@ const Community = () => {
 
     const { selectedTeam } = useLeagueTeamStore();
 
-    const tabs = [
-        { type: "text", label: "전체", value: "전체" },
-        { type: "text", label: "인기", value: "인기" },
-        selectedTeam?.nameKr && { type: "text", label: selectedTeam.nameKr, value: selectedTeam.nameKr },
-    ].filter(Boolean);
+    const tabs = ["전체", "인기", selectedTeam?.nameKr || ""];
 
     useEffect(() => {
         const fetchPosts = async () => {
@@ -67,33 +63,22 @@ const Community = () => {
         }
     };
 
-    const handleTabClick = (tab) => {
-        setActiveTab(tab);
-        setActivePage(1); // Reset to the first page when switching tabs
-    };
-
     return (
         <NewsContainer>
-            {/* Replace old tab styling with News component tab styling */}
-            <NavContainer>
+            <TabContainer>
                 {tabs.map((tab) => (
-                    <TabButton
-                        key={tab.value}
-                        isActive={activeTab === tab.value}
-                        onClick={() => handleTabClick(tab.value)}
+                    <Tab
+                        key={tab}
+                        active={activeTab === tab}
+                        onClick={() => {
+                            setActiveTab(tab);
+                            setActivePage(1); // Reset page on tab change
+                        }}
                     >
-                        {tab.label}
-                    </TabButton>
+                        {tab}
+                    </Tab>
                 ))}
-            </NavContainer>
-
-            <Divider>
-                {tabs.map((tab, idx) =>
-                        tab.value === activeTab && (
-                            <ActiveIndicator key={tab.value} left={`calc(${idx} * 3rem + 0.7rem)`} />
-                        )
-                )}
-            </Divider>
+            </TabContainer>
 
             <TableHeader>
                 <div className="title">제목</div>

--- a/src/pages/Community/community.jsx
+++ b/src/pages/Community/community.jsx
@@ -138,7 +138,6 @@ const Community = () => {
                     </PS.NavButton>
                 </PS.PaginationWrapper>
             </S.NewsContainer>
-            <CommunityBoard type="communityDetail" />
         </>
     );
 };

--- a/src/pages/Community/community.jsx
+++ b/src/pages/Community/community.jsx
@@ -63,6 +63,14 @@ const Community = () => {
         }
     };
 
+    const formatDate = (dateString) => {
+        const date = new Date(dateString);
+        const year = date.getFullYear();
+        const month = (date.getMonth() + 1).toString().padStart(2, '0');
+        const day = date.getDate().toString().padStart(2, '0');
+        return `${year}.${month}.${day}`;
+    };
+
     return (
         <NewsContainer>
             <TabContainer>
@@ -102,7 +110,8 @@ const Community = () => {
                             <img src={post.user.profileImageUrl || ProfileIcon} alt="프로필 아이콘" />
                             {post.user.nickname}
                         </PostAuthor>
-                        <PostDate>{new Date(post.createdAt).toLocaleDateString()}</PostDate>
+                        <PostDate>{formatDate(post.createdAt)}</PostDate>
+
                         <PostViews>{post.views}</PostViews>
                         <PostLikes>{post.likes}</PostLikes>
                     </PostItem>

--- a/src/pages/Community/community.jsx
+++ b/src/pages/Community/community.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import {
-    NewsContainer, Tab, TabContainer, TableHeader, PostAuthor, PostDate,
-    PostItem, PostLikes, PostsWrapper, PostTitle, PostViews
+    NewsContainer,  NavContainer, TabButton, Divider, ActiveIndicator, PostAuthor, PostDate,
+    PostItem, PostLikes, PostsWrapper, PostTitle, PostViews, TableHeader
 } from "./community.style.js";
 import GoodIcon from "../../assets/good_black.svg";
 import ProfileIcon from "../../assets/profile.svg";
@@ -21,7 +21,11 @@ const Community = () => {
 
     const { selectedTeam } = useLeagueTeamStore();
 
-    const tabs = ["전체", "인기", selectedTeam?.nameKr || ""];
+    const tabs = [
+        { type: "text", label: "전체", value: "전체" },
+        { type: "text", label: "인기", value: "인기" },
+        selectedTeam?.nameKr && { type: "text", label: selectedTeam.nameKr, value: selectedTeam.nameKr },
+    ].filter(Boolean);
 
     useEffect(() => {
         const fetchPosts = async () => {
@@ -63,22 +67,33 @@ const Community = () => {
         }
     };
 
+    const handleTabClick = (tab) => {
+        setActiveTab(tab);
+        setActivePage(1); // Reset to the first page when switching tabs
+    };
+
     return (
         <NewsContainer>
-            <TabContainer>
+            {/* Replace old tab styling with News component tab styling */}
+            <NavContainer>
                 {tabs.map((tab) => (
-                    <Tab
-                        key={tab}
-                        active={activeTab === tab}
-                        onClick={() => {
-                            setActiveTab(tab);
-                            setActivePage(1); // Reset page on tab change
-                        }}
+                    <TabButton
+                        key={tab.value}
+                        isActive={activeTab === tab.value}
+                        onClick={() => handleTabClick(tab.value)}
                     >
-                        {tab}
-                    </Tab>
+                        {tab.label}
+                    </TabButton>
                 ))}
-            </TabContainer>
+            </NavContainer>
+
+            <Divider>
+                {tabs.map((tab, idx) =>
+                        tab.value === activeTab && (
+                            <ActiveIndicator key={tab.value} left={`calc(${idx} * 3rem + 0.7rem)`} />
+                        )
+                )}
+            </Divider>
 
             <TableHeader>
                 <div className="title">제목</div>

--- a/src/pages/Community/community.jsx
+++ b/src/pages/Community/community.jsx
@@ -10,7 +10,6 @@ import { useNavigate } from "react-router-dom";
 import axiosInstance from "../../apis/axios-instance";
 import {formatDate} from "../../utils/formatDate.js";
 import NoData from "../../components/NoData/noData.jsx";
-import CommunityBoard from "../../components/CommunityBoard/communityBoard.jsx";
 
 const Community = () => {
     const [posts, setPosts] = useState([]);

--- a/src/pages/Community/community.jsx
+++ b/src/pages/Community/community.jsx
@@ -11,6 +11,7 @@ import { useLeagueTeamStore } from '../../store/useLeagueTeamStore';
 import { GrFormNext, GrFormPrevious } from "react-icons/gr";
 import { useNavigate } from "react-router-dom";
 import axiosInstance from "../../apis/axios-instance";
+import {formatDate} from "../../utils/formatDate.js";
 
 const Community = () => {
     const [posts, setPosts] = useState([]);
@@ -63,14 +64,6 @@ const Community = () => {
         }
     };
 
-    const formatDate = (dateString) => {
-        const date = new Date(dateString);
-        const year = date.getFullYear();
-        const month = (date.getMonth() + 1).toString().padStart(2, '0');
-        const day = date.getDate().toString().padStart(2, '0');
-        return `${year}.${month}.${day}`;
-    };
-
     return (
         <NewsContainer>
             <TabContainer>
@@ -103,9 +96,12 @@ const Community = () => {
                 {posts.map((post) => (
                     <PostItem key={post.pk} onClick={() => handlePostClick(post.pk)}>
                         <PostTitle>
-                            {post.title}
-                            {post.replies > 0 && <span className="reply-count">({post.replies})</span>}
+                            <span className="clamp">
+                                {post.title}
+                                {post.replies > 0 && <span className="reply-count">({post.replies})</span>}
+                            </span>
                         </PostTitle>
+
                         <PostAuthor>
                             <img src={post.user.profileImageUrl || ProfileIcon} alt="프로필 아이콘" />
                             {post.user.nickname}

--- a/src/pages/Community/community.style.js
+++ b/src/pages/Community/community.style.js
@@ -57,7 +57,7 @@ export const TableHeader = styled.div`
         text-align: center;
     }
     .date {
-        flex: 1.5;
+        flex: 2;
         text-align: center;
     }
     
@@ -97,12 +97,13 @@ export const PostItem = styled.div`
 `;
 
 export const PostTitle = styled.div`
-    flex: 4;
+    flex: 3.5;
     font-size: 0.65rem;
     font-weight: 500;
     overflow: hidden;
     text-overflow: ellipsis;
     padding-left: 0.5rem;
+    padding-right: 1.25rem;
     color: black;
     display: -webkit-box;
     -webkit-line-clamp: 2; /* 최대 2줄까지 표시 */
@@ -128,7 +129,7 @@ export const PostAuthor = styled.div`
   color: #000;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 0.25rem;
   font-weight: 350;
 
@@ -141,22 +142,30 @@ export const PostAuthor = styled.div`
 `;
 
 export const PostDate = styled.div`
-  flex: 2;
-  font-size: 0.6rem;
-  color: #8c8c8c;
-  text-align: center;
+    flex: 2;
+    font-size: 0.6rem;
+    color: #8c8c8c;
+    text-align: center;
 `;
 
 export const PostLikes = styled.div`
-  flex: 1;
-  font-size: 0.6rem;
-  color: #8f8f8f;
-  text-align: center;
+    width: auto;
+    flex: 1;
+    min-width: 2rem;
+    font-size: 0.6rem;
+    color: #8f8f8f;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 `;
 
 export const PostViews = styled.div`
-  flex: 1;
-  font-size: 0.6rem;
-  color: #8f8f8f;
-  text-align: center;
+    width: auto;
+    flex: 1;
+    min-width: 2rem;
+    font-size: 0.6rem;
+    color: #8f8f8f;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 `;

--- a/src/pages/Community/community.style.js
+++ b/src/pages/Community/community.style.js
@@ -10,32 +10,48 @@ export const NewsContainer = styled.div`
     background: #FFF;
     display: flex;
     flex-direction: column;
-    padding: 0.7rem;
+    padding: 1.33rem 0.7rem 1.77rem 0.7rem;;
 `;
 
-export const TabContainer = styled.div`
-    display: flex;
-    border-bottom: 1px solid #F0F0F0;
-    margin-bottom: 1rem;
+export const NavContainer = styled.div`
+  display: flex;
+  align-items: center;
+  margin: 0 0 0.66rem 1rem;
+  gap: 1rem;
 `;
 
-export const Tab = styled.div`
-    color: ${props => props.active ? '#C00C0B' : '#676767'};
-    font-family: Pretendard;
-    font-size: 0.8rem;
-    font-weight: ${props => props.active ? '600' : '500'};
-    padding: 0.5rem 1rem;
-    cursor: pointer;
-    position: relative;
-    &:after {
-        content: '';
-        position: absolute;
-        bottom: -1px;
-        left: 0;
-        width: 100%;
-        height: 2px;
-        background-color: ${props => props.active ? '#C00C0B' : 'transparent'};
-    }
+export const TabButton = styled.div`
+    // 전체, 인기 등 탭 버튼
+  margin-right: 0.7rem;
+  text-align: center;
+  font-size: 0.7rem;
+  font-style: normal;
+  line-height: 0.7rem;
+  font-weight: ${props => props.isActive ? '500' : '400'};
+  color: ${props => props.isActive ? '#C00C0B' : '#000'};
+  cursor: pointer;
+`;
+
+export const Divider = styled.div`
+  width: 100%;
+  height: 0;
+  flex-shrink: 0;
+  stroke-width: 1px;
+  stroke: #DCDCDC;
+  filter: drop-shadow(0px 4px 12px rgba(0, 0, 0, 0.20));
+  border-bottom: 1px solid #DCDCDC;
+  position: relative;
+`;
+
+export const ActiveIndicator = styled.div`
+    position: absolute;
+    top: -1px;
+    width: 2rem;
+    height: 0;
+    stroke-width: 2px;
+    stroke: #C00C0B;
+    border-bottom: 2px solid #C00C0B;
+    left: ${props => props.left};
 `;
 
 export const TableHeader = styled.div`

--- a/src/pages/Community/community.style.js
+++ b/src/pages/Community/community.style.js
@@ -54,11 +54,11 @@ export const TableHeader = styled.div`
     }
     
     .author {
-        flex: 2.2;
+        flex: 2.14;
         text-align: center;
     }
     .date {
-        flex: 2;
+        flex: 1.5;
         text-align: center;
     }
     
@@ -129,7 +129,7 @@ export const PostTitle = styled.div`
 
 
 export const PostAuthor = styled.div`
-  flex: 2.2;
+  flex: 2.14;
   font-size: 0.55rem;
   color: #000;
   display: flex;
@@ -147,7 +147,7 @@ export const PostAuthor = styled.div`
 `;
 
 export const PostDate = styled.div`
-    flex: 2;
+    flex: 1.5;
     font-size: 0.55rem;
     color: #8c8c8c;
     text-align: center;

--- a/src/pages/Community/community.style.js
+++ b/src/pages/Community/community.style.js
@@ -20,10 +20,10 @@ export const TabContainer = styled.div`
 `;
 
 export const Tab = styled.div`
-    color: ${props => props.active ? '#C00C0B' : '#676767'};
+    color: ${props => props.active ? '#C00C0B' : '#000'};
     font-family: Pretendard;
-    font-size: 0.8rem;
-    font-weight: ${props => props.active ? '600' : '500'};
+    font-size: 0.7rem;
+    font-weight: ${props => props.active ? '500' : '400'};
     padding: 0.5rem 1rem;
     cursor: pointer;
     position: relative;

--- a/src/pages/Community/community.style.js
+++ b/src/pages/Community/community.style.js
@@ -10,48 +10,32 @@ export const NewsContainer = styled.div`
     background: #FFF;
     display: flex;
     flex-direction: column;
-    padding: 1.33rem 0.7rem 1.77rem 0.7rem;;
+    padding: 1.33rem 0.7rem 1.77rem 0.7rem;
 `;
 
-export const NavContainer = styled.div`
-  display: flex;
-  align-items: center;
-  margin: 0 0 0.66rem 1rem;
-  gap: 1rem;
+export const TabContainer = styled.div`
+    display: flex;
+    border-bottom: 1px solid #F0F0F0;
+    margin-bottom: 1rem;
 `;
 
-export const TabButton = styled.div`
-    // 전체, 인기 등 탭 버튼
-  margin-right: 0.7rem;
-  text-align: center;
-  font-size: 0.7rem;
-  font-style: normal;
-  line-height: 0.7rem;
-  font-weight: ${props => props.isActive ? '500' : '400'};
-  color: ${props => props.isActive ? '#C00C0B' : '#000'};
-  cursor: pointer;
-`;
-
-export const Divider = styled.div`
-  width: 100%;
-  height: 0;
-  flex-shrink: 0;
-  stroke-width: 1px;
-  stroke: #DCDCDC;
-  filter: drop-shadow(0px 4px 12px rgba(0, 0, 0, 0.20));
-  border-bottom: 1px solid #DCDCDC;
-  position: relative;
-`;
-
-export const ActiveIndicator = styled.div`
-    position: absolute;
-    top: -1px;
-    width: 2rem;
-    height: 0;
-    stroke-width: 2px;
-    stroke: #C00C0B;
-    border-bottom: 2px solid #C00C0B;
-    left: ${props => props.left};
+export const Tab = styled.div`
+    color: ${props => props.active ? '#C00C0B' : '#676767'};
+    font-family: Pretendard;
+    font-size: 0.8rem;
+    font-weight: ${props => props.active ? '600' : '500'};
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    position: relative;
+    &:after {
+        content: '';
+        position: absolute;
+        bottom: -1px;
+        left: 0;
+        width: 100%;
+        height: 2px;
+        background-color: ${props => props.active ? '#C00C0B' : 'transparent'};
+    }
 `;
 
 export const TableHeader = styled.div`

--- a/src/pages/Community/community.style.js
+++ b/src/pages/Community/community.style.js
@@ -3,20 +3,19 @@ import styled from "styled-components";
 
 export const NewsContainer = styled.div`
     width: 30rem;
-    min-height: 55.625rem;
     flex-shrink: 0;
     border-radius: 0.45rem;
     border: 1px solid #DCDCDC;
     background: #FFF;
     display: flex;
     flex-direction: column;
-    padding: 1.33rem 0.7rem 1.77rem 0.7rem;
+    padding: 0.7rem;
 `;
 
 export const TabContainer = styled.div`
     display: flex;
     border-bottom: 1px solid #F0F0F0;
-    margin-bottom: 1rem;
+    margin-bottom: 0.5rem;
 `;
 
 export const Tab = styled.div`
@@ -24,7 +23,7 @@ export const Tab = styled.div`
     font-family: Pretendard;
     font-size: 0.7rem;
     font-weight: ${props => props.active ? '500' : '400'};
-    padding: 0.5rem 1rem;
+    padding: 0.5rem 0.7rem;
     cursor: pointer;
     position: relative;
     &:after {
@@ -48,12 +47,12 @@ export const TableHeader = styled.div`
     font-size: 0.6rem;
     font-weight: 400;
     .title {
-        flex: 4;
+        flex: 6;
         text-align: center;
     }
     
     .author {
-        flex: 2;
+        flex: 2.2;
         text-align: center;
     }
     .date {
@@ -87,7 +86,7 @@ export const PostItem = styled.div`
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  padding: 0.75rem 0;
+  padding: 0.55rem 0;
   border-bottom: 0.0625rem solid #f0f0f0;
   cursor: pointer;
   
@@ -97,35 +96,39 @@ export const PostItem = styled.div`
 `;
 
 export const PostTitle = styled.div`
-    flex: 3.5;
-    font-size: 0.65rem;
-    font-weight: 500;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    flex: 5.5;
+    font-size: 0.6rem;
+    font-weight: 350;
+    color: black;
     padding-left: 0.5rem;
     padding-right: 1.25rem;
-    color: black;
-    display: -webkit-box;
-    -webkit-line-clamp: 2; /* 최대 2줄까지 표시 */
-    -webkit-box-orient: vertical;
-    word-break: break-word;
+    min-width: 0;
 
-  img {
-    width: 0.6rem;
-    height: 0.6rem;
-    margin-left: 0.25rem;
-  }
+    .clamp {
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        word-break: break-word;
+        white-space: normal;
+        min-width: 0;
+        max-width: 100%;
+    }
 
-  .reply-count {
-    color: #000;
-    font-weight: normal;
-    margin-left: 0.25rem
-  }
+    .reply-count {
+        color: #000;
+        font-weight: normal;
+        margin-left: 0.15rem;
+        white-space: nowrap;
+    }
 `;
 
+
+
 export const PostAuthor = styled.div`
-  flex: 2;
-  font-size: 0.6rem;
+  flex: 2.2;
+  font-size: 0.55rem;
   color: #000;
   display: flex;
   align-items: center;
@@ -143,7 +146,7 @@ export const PostAuthor = styled.div`
 
 export const PostDate = styled.div`
     flex: 2;
-    font-size: 0.6rem;
+    font-size: 0.55rem;
     color: #8c8c8c;
     text-align: center;
 `;
@@ -152,7 +155,7 @@ export const PostLikes = styled.div`
     width: auto;
     flex: 1;
     min-width: 2rem;
-    font-size: 0.6rem;
+    font-size: 0.55rem;
     color: #8f8f8f;
     display: flex;
     align-items: center;
@@ -163,7 +166,7 @@ export const PostViews = styled.div`
     width: auto;
     flex: 1;
     min-width: 2rem;
-    font-size: 0.6rem;
+    font-size: 0.55rem;
     color: #8f8f8f;
     display: flex;
     align-items: center;

--- a/src/pages/News/news.jsx
+++ b/src/pages/News/news.jsx
@@ -94,6 +94,7 @@ const News = () => {
                             activeTab={activeTab}
                         />
                     </S.LeagueTab>
+
                 </S.TabContainer>
 
                 <S.NewsList>

--- a/src/pages/News/news.jsx
+++ b/src/pages/News/news.jsx
@@ -18,16 +18,7 @@ const News = () => {
     const navigate = useNavigate();
     const leaguePk = selectedLeague?.pk || undefined;
 
-    const tabs = [
-        { type: "text", label: "전체", value: "전체" },
-        { type: "text", label: "인기", value: "인기" },
-        selectedTeam?.nameKr && { type: "text", label: selectedTeam.nameKr, value: selectedTeam.nameKr },
-    ].filter(Boolean);
-
-    const handleTabClick = (tab) => {
-        setActiveTab(tab);
-        setActivePage(1); // Reset to the first page when switching tabs
-    };
+    const tabs = ["전체", "인기", selectedTeam?.nameKr || ""].filter(Boolean);
 
     useEffect(() => {
         const fetchNews = async () => {
@@ -72,38 +63,38 @@ const News = () => {
     return (
         <S.Container>
             <S.NewsContainer>
-                <S.NavContainer>
-                    {tabs.map((tab, index) => (
-                        <S.TabButton
-                            key={tab.value}
-                            isActive={activeTab === tab.value}
-                            onClick={() => handleTabClick(tab.value)}
+                {/* New Tab Styling from Community */}
+                <S.TabContainer>
+                    {tabs.map((tab) => (
+                        <S.Tab
+                            key={tab}
+                            active={activeTab === tab}
+                            onClick={() => {
+                                setActiveTab(tab);
+                                setActivePage(1); // Reset page on tab change
+                            }}
                         >
-                            {tab.label}
-                        </S.TabButton>
+                            {tab}
+                        </S.Tab>
                     ))}
-
-                    <LeagueDropdown
-                        selectedLeague={selectedLeague}
-                        setSelectedLeague={(league) => {
-                            setSelectedLeague(league);
-                            setActiveTab(league.nameKr);
-                            setActivePage(1);
+                    {/* LeagueTab으로 변경하여 위치 조정 적용 */}
+                    <S.LeagueTab
+                        active={selectedLeague?.nameKr === activeTab}
+                        onClick={() => {
+                            // We will use the dropdown's onClick behavior
                         }}
-                        activeTab={activeTab}
-                    />
-                </S.NavContainer>
-
-                <S.Divider>
-                    {tabs.map((tab, idx) =>
-                            tab.value === activeTab && (
-                                <S.ActiveIndicator key={tab.value} left={`calc(${idx} * 3rem + 0.7rem)`} />
-                            )
-                    )}
-                    {selectedLeague?.nameKr === activeTab && (
-                        <S.ActiveIndicator left={`calc(${tabs.length} * 3rem + 1rem)`} />
-                    )}
-                </S.Divider>
+                    >
+                        <LeagueDropdown
+                            selectedLeague={selectedLeague}
+                            setSelectedLeague={(league) => {
+                                setSelectedLeague(league);
+                                setActiveTab(league.nameKr);
+                                setActivePage(1);
+                            }}
+                            activeTab={activeTab}
+                        />
+                    </S.LeagueTab>
+                </S.TabContainer>
 
                 <S.NewsList>
                     {newsList.map((item) => (
@@ -116,7 +107,7 @@ const News = () => {
 
                 <PS.PaginationWrapper>
                     <PS.NavButton onClick={() => activePage > 1 && setActivePage(prev => prev - 1)}
-                                 disabled={activePage === 1}>
+                                  disabled={activePage === 1}>
                         <GrFormPrevious /> 이전
                     </PS.NavButton>
                     {Array.from({ length: totalPages }, (_, i) => (
@@ -129,7 +120,7 @@ const News = () => {
                         </PS.PageButton>
                     ))}
                     <PS.NavButton onClick={() => activePage < totalPages && setActivePage(prev => prev + 1)}
-                                 disabled={activePage === totalPages}>
+                                  disabled={activePage === totalPages}>
                         다음 <GrFormNext />
                     </PS.NavButton>
                 </PS.PaginationWrapper>

--- a/src/pages/News/news.style.js
+++ b/src/pages/News/news.style.js
@@ -13,7 +13,7 @@ export const NewsContainer = styled.div`
     border-radius: 0.44rem;
     border: 1px solid #DCDCDC;
     background: #FFF;
-    padding: 1.33rem 0.7rem 1.77rem 0.7rem;
+    padding: 0.7rem;
     margin-bottom: 6.19rem;
     position: relative;
 `;
@@ -29,7 +29,7 @@ export const Tab = styled.div`
     font-family: Pretendard;
     font-size: 0.7rem;
     font-weight: ${props => props.active ? '500' : '400'};
-    padding: 0.5rem 1rem;
+    padding: 0.5rem 0.7rem;
     cursor: pointer;
     position: relative;
     &:after {
@@ -43,36 +43,10 @@ export const Tab = styled.div`
     }
 `;
 
-// 리그 드롭다운을 위한 특별 탭 스타일
 export const LeagueTab = styled(Tab)`
     display: flex;
     align-items: center;
     
-    /* 레이아웃 조정을 위한 스타일 */
-    & > div {
-        display: flex;
-        align-items: center;
-        margin: 0;
-        padding: 0;
-        transform: translateY(0);
-        line-height: normal;
-        font-size: 0.8rem;
-    }
-    
-    /* 드롭다운 컴포넌트 내부 스타일 조정 */
-    & > div > * {
-        font-size: 0.8rem;
-        font-weight: inherit;
-        margin: 0;
-        padding: 0;
-        vertical-align: middle;
-    }
-    
-    /* 텍스트가 중앙에 위치하도록 조정 */
-    & div {
-        display: flex;
-        align-items: center;
-    }
 `;
 
 export const NewsList = styled.div`

--- a/src/pages/News/news.style.js
+++ b/src/pages/News/news.style.js
@@ -25,10 +25,10 @@ export const TabContainer = styled.div`
 `;
 
 export const Tab = styled.div`
-    color: ${props => props.active ? '#C00C0B' : '#676767'};
+    color: ${props => props.active ? '#C00C0B' : '#000'};
     font-family: Pretendard;
-    font-size: 0.8rem;
-    font-weight: ${props => props.active ? '600' : '500'};
+    font-size: 0.7rem;
+    font-weight: ${props => props.active ? '500' : '400'};
     padding: 0.5rem 1rem;
     cursor: pointer;
     position: relative;
@@ -54,9 +54,9 @@ export const LeagueTab = styled(Tab)`
         align-items: center;
         margin: 0;
         padding: 0;
-        /* 텍스트 위치 조정 */
         transform: translateY(0);
         line-height: normal;
+        font-size: 0.8rem;
     }
     
     /* 드롭다운 컴포넌트 내부 스타일 조정 */

--- a/src/pages/News/news.style.js
+++ b/src/pages/News/news.style.js
@@ -1,73 +1,89 @@
 import styled from "styled-components";
 
 export const Container = styled.div`
-  width: 100%;
-  display: flex;
-  justify-content: center;
+    width: 100%;
+    display: flex;
+    justify-content: center;
 `;
 
 export const NewsContainer = styled.div`
-  width: 30rem;
-  //height: 116.2rem;
-  flex-shrink: 0;
-  border-radius: 0.44rem;
-  border: 1px solid #DCDCDC;
-  background: #FFF;
-  padding: 1.33rem 0.7rem 1.77rem 0.7rem;
-  margin-bottom: 6.19rem;
-  position: relative;
+    width: 30rem;
+    //height: 116.2rem;
+    flex-shrink: 0;
+    border-radius: 0.44rem;
+    border: 1px solid #DCDCDC;
+    background: #FFF;
+    padding: 1.33rem 0.7rem 1.77rem 0.7rem;
+    margin-bottom: 6.19rem;
+    position: relative;
 `;
 
-export const NavContainer = styled.div`
-  display: flex;
-  align-items: center;
-  margin: 0 0 0.66rem 1rem;
-  gap: 1rem;
+export const TabContainer = styled.div`
+    display: flex;
+    border-bottom: 1px solid #F0F0F0;
+    margin-bottom: 1rem;
 `;
 
-export const TabButton = styled.div`
-    // 전체, 인기 등 탭 버튼
-  margin-right: 0.7rem;
-  text-align: center;
-  font-size: 0.7rem;
-  font-style: normal;
-  line-height: 0.7rem;
-  font-weight: ${props => props.isActive ? '500' : '400'};
-  color: ${props => props.isActive ? '#C00C0B' : '#000'};
-  cursor: pointer;
+export const Tab = styled.div`
+    color: ${props => props.active ? '#C00C0B' : '#676767'};
+    font-family: Pretendard;
+    font-size: 0.8rem;
+    font-weight: ${props => props.active ? '600' : '500'};
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    position: relative;
+    &:after {
+        content: '';
+        position: absolute;
+        bottom: -1px;
+        left: 0;
+        width: 100%;
+        height: 2px;
+        background-color: ${props => props.active ? '#C00C0B' : 'transparent'};
+    }
 `;
 
-export const Divider = styled.div`
-  width: 100%;
-  height: 0;
-  flex-shrink: 0;
-  stroke-width: 1px;
-  stroke: #DCDCDC;
-  filter: drop-shadow(0px 4px 12px rgba(0, 0, 0, 0.20));
-  border-bottom: 1px solid #DCDCDC;
-  position: relative;
-`;
-
-export const ActiveIndicator = styled.div`
-    position: absolute;
-    top: -1px;
-    width: 2rem;
-    height: 0;
-    stroke-width: 2px;
-    stroke: #C00C0B;
-    border-bottom: 2px solid #C00C0B;
-    left: ${props => props.left};
+// 리그 드롭다운을 위한 특별 탭 스타일
+export const LeagueTab = styled(Tab)`
+    display: flex;
+    align-items: center;
+    
+    /* 레이아웃 조정을 위한 스타일 */
+    & > div {
+        display: flex;
+        align-items: center;
+        margin: 0;
+        padding: 0;
+        /* 텍스트 위치 조정 */
+        transform: translateY(0);
+        line-height: normal;
+    }
+    
+    /* 드롭다운 컴포넌트 내부 스타일 조정 */
+    & > div > * {
+        font-size: 0.8rem;
+        font-weight: inherit;
+        margin: 0;
+        padding: 0;
+        vertical-align: middle;
+    }
+    
+    /* 텍스트가 중앙에 위치하도록 조정 */
+    & div {
+        display: flex;
+        align-items: center;
+    }
 `;
 
 export const NewsList = styled.div`
-  margin-top: 1rem;
-        /* 첫 번째 아이템을 제외한 모든 아이템에 상단 간격 추가 */
-        & > div + div {
-                margin-top: 1rem;
-        }
+    margin-top: 1rem;
+    /* 첫 번째 아이템을 제외한 모든 아이템에 상단 간격 추가 */
+    & > div + div {
+        margin-top: 1rem;
+    }
 
-        /* 마지막 아이템의 하단 테두리 제거 */
-        & > div:last-child {
-                border-bottom: none;
-        }
+    /* 마지막 아이템의 하단 테두리 제거 */
+    & > div:last-child {
+        border-bottom: none;
+    }
 `;

--- a/src/pages/ProfileSettings/ProfileSettings.jsx
+++ b/src/pages/ProfileSettings/ProfileSettings.jsx
@@ -94,8 +94,8 @@ const ProfileSettings = () => {
     setNickname(value);
     if (!value.length) {
       setNicknameError("닉네임을 입력해 주세요.");
-    } else if (value.length > 10) {
-      setNicknameError("닉네임은 10자 이하로 작성해주세요.");
+    } else if (value.length > 8) {
+      setNicknameError("닉네임은 8자 이하로 작성해주세요.");
     } else {
       setNicknameError("");
     }

--- a/src/utils/formatDate.js
+++ b/src/utils/formatDate.js
@@ -1,0 +1,7 @@
+export const formatDate = (dateString) => {
+    const date = new Date(dateString);
+    const year = date.getFullYear();
+    const month = (date.getMonth() + 1).toString().padStart(2, '0');
+    const day = date.getDate().toString().padStart(2, '0');
+    return `${year}.${month}.${day}`;
+};


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #102 

## ✨ 작업 개요
> 탑 뉴스 클릭하면 상세보기로 전환되게 했습니다 또한 게시글 리스트 UI를 개선하였습니다

## 📷 이미지 첨부 (선택)
- 글쓴이 좌측정렬 & 날짜 출력 포맷 수정
![image](https://github.com/user-attachments/assets/c1f8f725-e4da-4e1b-a4c5-e40bda882ff0)

- 헤더 통일화
- 리그 드롭다운 위치 수정
![image](https://github.com/user-attachments/assets/d67052f0-f935-475d-ba95-bbcc5b672939)
- 게시글리스트 전반적 UI 수정
![image](https://github.com/user-attachments/assets/65856d56-d386-43a0-8551-3ff7f48ca97f)

## 🧐 집중 리뷰 요청
> 현재 이미지가 있을 때 이미지 아이콘 생겨야되는데, 로직 구상이 어려워 논의 후 수정 예정
