### PR TITLE
Feat: 승부예측랭킹 설명 추가

### DIFF
--- a/src/components/RankingTable/rankingTable.jsx
+++ b/src/components/RankingTable/rankingTable.jsx
@@ -8,6 +8,7 @@ import {
 } from "../../apis/domains/ranking/ranking.js";
 import NoData from "../NoData/noData.jsx"
 import LoadingSpinner from "../LoadingSpinner/loadingSpinner.jsx";
+import { RiQuestionLine } from "react-icons/ri";
 
 const RankingTable = ({ title, type = "season" }) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -103,7 +104,20 @@ const RankingTable = ({ title, type = "season" }) => {
 
   return (
     <S.TableContainer>
-      <S.Title>{title}</S.Title>
+      <S.Title>
+        {title}
+        {type === "gamble" && (
+            <S.HelpWrapper>
+              <RiQuestionLine size="0.8rem" color="#aaa" style={{ verticalAlign: "center" }}/>
+              <S.Tooltip>
+                승부예측은 경기 결과를 맞히는 기능입니다.<br />
+                예측이 적중하면 포인트가 적립되고,<br />
+                이 포인트를 기반으로 내가 응원하는 팀의<br />
+                승부예측 순위가 결정됩니다.<br />
+              </S.Tooltip>
+            </S.HelpWrapper>
+        )}
+      </S.Title>
       <S.Divider />
       {selectedLeague && (
         <S.LeagueSelector onClick={toggleDropdown}>

--- a/src/components/RankingTable/rankingTable.style.js
+++ b/src/components/RankingTable/rankingTable.style.js
@@ -166,3 +166,33 @@ export const TeamName = styled.span`
   text-align: left;
 `;
 
+export const HelpWrapper = styled.span`
+  position: relative;
+  display: inline-block;
+  margin-left: 0.5rem;
+
+  &:hover > div {
+    opacity: 1;
+    visibility: visible;
+  }
+`;
+
+export const Tooltip = styled.div`
+  position: absolute;
+  top: 120%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: max-content;
+  max-width: 250px;
+  background-color: #333;
+  color: #FFF;
+  padding: 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 400;
+  border-radius: 4px;
+  white-space: pre-line;
+  z-index: 10;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease;
+`;


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #127 

## ✨ 작업 개요
> 작업 내용을 간략하게 작성해주세요.
- 승부예측 랭킹 테이블에 설명을 추가했습니다.

## 📷 이미지 첨부 (선택)
- 작업 결과를 확인할 수 있는 이미지나 GIF를 첨부해주세요.  
- UI 변경, API 응답 샘플, 테스트 결과 등이 포함되면 좋아요!
<img width="762" alt="image" src="https://github.com/user-attachments/assets/b53d52af-d492-4718-b196-ec73385eb8e2" />


## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
