### PR TITLE
fix: 클럽 커뮤니티 사용자 이미지 깨짐 현상

### DIFF
--- a/src/components/CommunityBoard/communityBoard.jsx
+++ b/src/components/CommunityBoard/communityBoard.jsx
@@ -21,6 +21,7 @@ import {formatDate} from "../../utils/formatDate.js";
 import NoData from "../../components/NoData/noData.jsx";
 import { increaseViewCount } from "../../utils/increaseViewCount";
 import LoadingSpinner from "../LoadingSpinner/loadingSpinner.jsx";
+import defaultProfileImage from "../../assets/profile.svg";
 
 const CommunityBoard = ({ type }) => {
   const [posts, setPosts] = useState([]);
@@ -94,7 +95,7 @@ const CommunityBoard = ({ type }) => {
                   </PostTitle>
                   <PostAuthor>
                     <img
-                        src={post.user.profileImageUrl}
+                        src={post.user.profileImageUrl ? post.user.profileImageUrl : defaultProfileImage}
                         alt="프로필"
                         style={{
                           width: '0.78rem',


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #132 

## ✨ 작업 개요
- 사용자 프로필 이미지가 없거나 로딩 오류가 발생할 경우, 깨진 이미지 대신 기본 이미지로 대체되도록 클럽 커뮤니티 컴포넌트를 수정했습니다.

## 📷 이미지 첨부 (선택)
![클럽 커뮤니티 사용자 이미지 깨짐 현상](https://github.com/user-attachments/assets/9d202904-5adf-421c-94c4-d9f5886ea598)
- 위 issue 개선했습니다.

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
