### PR TITLE
Feat: 이적 예측 로딩 중 뉴스 기능 구현

### DIFF
--- a/src/components/NewsList/NewsItem.jsx
+++ b/src/components/NewsList/NewsItem.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import defaultProfileImage from "../../assets/profile.svg"; // 기본 프로필 이미지 import
+import defaultTeamLogo from "../../assets/good.svg"; // 기본 팀 로고로 일단 good.svg를 사용
 import {
   NewsItemContainer,
   NewsBadge,
@@ -28,17 +29,51 @@ import GoodIcon from "../../assets/good.svg";
 import {stripHtml} from "../../utils/stripHtml.js";
 import { increaseViewCount } from "../../utils/increaseViewCount";
 
-const NewsItem = ({ pk, title, content, thumbnailUrl, user, createdAt, views, likes, replies, category }) => {
+const NewsItem = ({ pk, title, content, thumbnailUrl, user, createdAt, views, likes, replies, category, team, onNewsClick, isCompact }) => {
   const navigate = useNavigate();
-  const plainTextContent = stripHtml(content).substring(0, 100) + (stripHtml(content).length > 100 ? "..." : "");
+  const plainTextContent = stripHtml(content).substring(0, isCompact ? 50 : 100) + (stripHtml(content).length > (isCompact ? 50 : 100) ? "..." : "");
 
   const handleClick = async () => {
     try {
       await increaseViewCount("news", pk);
-      navigate(`/news/${pk}`);
+      
+      if (onNewsClick) {
+        // 상세 뉴스 데이터를 객체로 전달
+        onNewsClick({
+          pk,
+          title,
+          content,
+          thumbnailUrl,
+          user,
+          createdAt,
+          views: views + 1, // 조회수 증가
+          likes,
+          replies,
+          category,
+          team
+        });
+      } else {
+        navigate(`/news/${pk}`);
+      }
     } catch (error) {
       console.error("조회수 증가 실패:", error);
-      navigate(`/news/${pk}`);
+      if (onNewsClick) {
+        onNewsClick({
+          pk,
+          title,
+          content,
+          thumbnailUrl,
+          user,
+          createdAt,
+          views,
+          likes,
+          replies,
+          category,
+          team
+        });
+      } else {
+        navigate(`/news/${pk}`);
+      }
     }
   };
 
@@ -46,14 +81,14 @@ const NewsItem = ({ pk, title, content, thumbnailUrl, user, createdAt, views, li
   const profileImage = user.profileImageUrl || defaultProfileImage;
 
   return (
-      <NewsItemContainer onClick={handleClick}>
+      <NewsItemContainer onClick={handleClick} className={isCompact ? 'news-item compact' : ''}>
         <ContentWrapper>
           <TextContentWrapper>
             <TopSection>
               <div>
                 <NewsBadge>{category}</NewsBadge>
-                <NewsTitle>{title}</NewsTitle>
-                <NewsContent>{plainTextContent}</NewsContent>
+                <NewsTitle className="title">{title}</NewsTitle>
+                <NewsContent className="content">{plainTextContent}</NewsContent>
                 <LeftInfo>
                   <ProfileIcon src={profileImage} alt="Profile" />
                   <Nickname>{user.nickname}</Nickname>
@@ -67,7 +102,7 @@ const NewsItem = ({ pk, title, content, thumbnailUrl, user, createdAt, views, li
                   <Reads>읽음 {views}</Reads>
                 </LeftInfo>
               </div>
-              {thumbnailUrl && <Thumbnail src={thumbnailUrl} alt="Thumbnail" />}
+              {thumbnailUrl && <Thumbnail className="thumbnail" src={thumbnailUrl} alt="Thumbnail" />}
             </TopSection>
             <RightInfo>
               <img src={GoodIcon} alt="좋아요" style={{ width: '0.7rem', height: '0.7rem', marginRight: '0.1rem' }} />

--- a/src/components/NewsList/NewsItem.style.js
+++ b/src/components/NewsList/NewsItem.style.js
@@ -84,7 +84,8 @@ export const Thumbnail = styled.img`
   flex-shrink: 0;
   border-radius: 0.36rem;
   object-fit: cover; // 이미지 비율 유지를 위해 추가
-  margin: 1rem 0 0 1rem;
+  margin: 0;
+  align-self: center;
 `;
 
 export const ProfileIcon = styled.img.attrs({
@@ -160,5 +161,6 @@ export const TopSection = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  align-items: center;
   width: 100%;
 `;

--- a/src/components/NewsList/NewsList.style.js
+++ b/src/components/NewsList/NewsList.style.js
@@ -11,19 +11,49 @@ export const NewsListContainer = styled.div`
   border-radius: 0.625rem;
   border: 0.0625rem solid #DCDCDC;
   background: #FFF;
-`;
-
-export const NewsItemsWrapper = styled.div`
-  width: 100%;
   
-  /* 첫 번째 아이템을 제외한 모든 아이템에 상단 간격 추가 */
-  & > div + div {
-    margin-top: 1rem;
-  }
-  
-  /* 마지막 아이템의 하단 테두리 제거 */
-  & > div:last-child {
-    border-bottom: none;
+  // 이적 예측 페이지에서만 사용될 때 스타일 변경
+  &.compact {
+    width: 100%;
+    padding: 0.5rem;
+    border: none;
+    border-radius: 0.45rem;
+    background-color: white;
+    margin-bottom: 1rem;
+    max-height: none; // 15.5rem에서 none으로 변경
+    overflow-y: visible; // auto에서 visible로 변경
+    
+    .news-item {
+      margin: 0;
+      padding: 0.3rem;
+      border-bottom: 1px solid #f0f0f0;
+      
+      &:last-child {
+        border-bottom: none;
+      }
+      
+      .title {
+        font-size: 0.85rem;
+        margin: 0.2rem 0;
+        display: -webkit-box;
+        -webkit-line-clamp: 1;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+      }
+      
+      .content {
+        font-size: 0.65rem;
+        margin-bottom: 0.3rem;
+        -webkit-line-clamp: 1;
+        line-height: 1.2;
+      }
+      
+      .thumbnail {
+        width: 3rem;
+        height: 3rem;
+        margin: 0;
+      }
+    }
   }
 `;
 
@@ -38,6 +68,7 @@ export const NewsHeader = styled.div`
   font-weight: 500;
   line-height: 1.25rem;
   color: black;
+  
   .title {
     display: flex;
     align-items: center;
@@ -72,4 +103,26 @@ export const MoreIcon = styled.div`
   background-image: url(${MoreSvg});
   background-size: contain;
   background-repeat: no-repeat;
+`;
+
+export const NewsItemsWrapper = styled.div`
+  width: 100%;
+  
+  /* 첫 번째 아이템을 제외한 모든 아이템에 상단 간격 추가 */
+  & > div + div {
+    margin-top: 1rem;
+  }
+  
+  /* 마지막 아이템의 하단 테두리 제거 */
+  & > div:last-child {
+    border-bottom: none;
+  }
+
+  .compact & {
+    margin-top: 0;
+    
+    & > div + div {
+      margin-top: 0.3rem;
+    }
+  }
 `;

--- a/src/components/NewsList/newsList.jsx
+++ b/src/components/NewsList/newsList.jsx
@@ -13,7 +13,7 @@ import { useLeagueTeamStore } from "../../store/useLeagueTeamStore";
 import NoData from "../../components/NoData/noData.jsx";
 import LoadingSpinner from "../LoadingSpinner/loadingSpinner.jsx";
 
-const NewsList = ({ type }) => {
+const NewsList = ({ type, onNewsClick, isCompact }) => {
   const [newsItems, setNewsItems] = useState([]);
   const [loading, setLoading] = useState(true);
 
@@ -24,6 +24,10 @@ const NewsList = ({ type }) => {
       setLoading(true);
       try {
         const result = await getHomeNewsList(type || " ");
+        console.log("뉴스 데이터 구조:", result);
+        if (Array.isArray(result) && result.length > 0) {
+          console.log("첫 번째 뉴스 아이템:", result[0]);
+        }
         setNewsItems(Array.isArray(result) ? result : []);
       } catch (error) {
         console.error("뉴스 데이터 로딩 실패:", error);
@@ -37,32 +41,49 @@ const NewsList = ({ type }) => {
   }, [type]);
 
   const getHeaderText = () => {
-    if (type === "other") return "함께 볼 만한 뉴스";
-    if (selectedTeam?.nameKr)
+    if (type === "other") {
+      return selectedTeam?.nameKr 
+        ? <>함께 볼 만한 <span style={{ color: "red" }}>{selectedTeam.nameKr}</span> 뉴스</>
+        : "함께 볼 만한 뉴스";
+    }
+    
+    if (selectedTeam?.nameKr) {
       return (
           <>
             함께 볼 만한 <span style={{ color: "red" }}>{selectedTeam.nameKr}</span> 뉴스
           </>
       );
+    }
+    
     return "함께 볼 만한 뉴스";
   };
 
   if (loading) return <LoadingSpinner />;
 
+  // 컴팩트 모드인 경우 표시할 뉴스 아이템 갯수 제한
+  const displayItems = isCompact ? newsItems.slice(0, 3) : newsItems;
+
   return (
-      <NewsListContainer>
+      <NewsListContainer className={isCompact ? 'compact' : ''}>
         <NewsHeader>
           <div className="title">{getHeaderText()}</div>
-          <MoreLink as={Link} to="/news">
-            더보기 <MoreIcon />
-          </MoreLink>
+          {!onNewsClick && (
+            <MoreLink as={Link} to="/news">
+              더보기 <MoreIcon />
+            </MoreLink>
+          )}
         </NewsHeader>
         <NewsItemsWrapper>
-          {newsItems.length === 0 ? (
+          {displayItems.length === 0 ? (
               <NoData />
           ) : (
-              newsItems.map((item) => (
-                  <NewsItem key={item.pk} {...item} />
+              displayItems.map((item) => (
+                  <NewsItem 
+                    key={item.pk} 
+                    {...item} 
+                    onNewsClick={onNewsClick}
+                    isCompact={isCompact} 
+                  />
               ))
           )}
         </NewsItemsWrapper>

--- a/src/pages/Transferability/transferability.jsx
+++ b/src/pages/Transferability/transferability.jsx
@@ -258,4 +258,4 @@ const Transferability = () => {
     );
 };
 
-export default Transferability;dd
+export default Transferability;

--- a/src/pages/Transferability/transferability.jsx
+++ b/src/pages/Transferability/transferability.jsx
@@ -1,19 +1,58 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef, useContext } from 'react';
 import * as S from './transferability.style.js';
 import ballIcon from '../../assets/good_black.svg';
 import playerImage from '../../assets/player.png';
 import NoData from '../../components/NoData/noData.jsx';
+import NewsList from '../../components/NewsList/newsList.jsx';
+import { FaCheckCircle } from "react-icons/fa";
+import defaultTeamLogo from '../../assets/good.svg';
+import { useNavigate } from 'react-router-dom';
+import { useAuthGuard } from '../../hooks/useAuthGuard.js';
+import { AuthContext } from '../../context/AuthContext.jsx';
+import { useDispatch } from 'react-redux';
+import { openLoginModal } from '../../features/modal/modalSlice.js';
+import defaultProfileImage from "../../assets/profile.svg";
 
 const Transferability = () => {
     const [inputValue, setInputValue] = useState('');
     const [transferResult, setTransferResult] = useState(null);
     const [isLoading, setIsLoading] = useState(false);
     const [hasError, setHasError] = useState(false);
+    const [predictionDone, setPredictionDone] = useState(false);
+    const [showResult, setShowResult] = useState(false);
+    const [selectedNews, setSelectedNews] = useState(null);
+    
+    // 로그인 상태 검증을 위한 설정
+    const navigate = useNavigate();
+    const { isAuthenticated } = useContext(AuthContext);
+    const dispatch = useDispatch();
+    
+    // 뉴스 컨텐츠 참조
+    const newsContentRef = useRef(null);
+
+    // 페이지 접근 시 로그인 상태 검증
+    useEffect(() => {
+        if (!isAuthenticated) {
+            // 로그인하지 않은 경우 홈으로 리다이렉트 후 로그인 모달 표시
+            navigate('/');
+            dispatch(openLoginModal());
+        }
+    }, [isAuthenticated, navigate, dispatch]);
+
+    // 뉴스 상세보기 시 내용 부분만 스크롤 가능하도록 설정
+    useEffect(() => {
+        if (newsContentRef.current) {
+            newsContentRef.current.scrollTop = 0;
+        }
+    }, [selectedNews]);
 
     const handlePredict = async () => {
         if (!inputValue.trim()) return;
         setIsLoading(true);
         setHasError(false);
+        setPredictionDone(false);
+        setShowResult(false);
+        setSelectedNews(null);
 
         try {
             const baseUrl = import.meta.env.VITE_API_PREDICT_URL;
@@ -38,6 +77,7 @@ const Transferability = () => {
             }
 
             setTransferResult(data);
+            setPredictionDone(true);
         } catch (error) {
             console.error('예측 요청 실패:', error);
             setHasError(true);
@@ -47,15 +87,56 @@ const Transferability = () => {
         }
     };
 
+    const handleShowResult = () => {
+        setShowResult(true);
+        setSelectedNews(null);
+    };
+    
+    const handleNewsClick = (newsItem) => {
+        setSelectedNews(newsItem);
+    };
+    
+    const handleBackToNewsList = () => {
+        setSelectedNews(null);
+    };
+
     const getMessage = (chance) => {
         if (chance > 0.7) return '🔥 이적 가능성이 매우 높습니다!';
         if (chance > 0.4) return '🧐 고민 중인 이적 후보입니다!';
         if (chance > 0.2) return '🙃 이적 가능성이 조금 있긴 합니다.';
-        return '👉 “로열티 높은 ‘우리’ 팀 선수입니다!”';
+        return `👉 "로열티 높은 '우리' 팀 선수입니다!"`;
+    };
+
+    // 컨테이너 높이 결정
+    const getContainerClass = () => {
+        if (selectedNews) {
+            return 'expanded';
+        }
+        if (isLoading || (predictionDone && !showResult)) {
+            return 'loading';
+        }
+        return '';
+    };
+
+    const formatDate = (dateString) => {
+        const date = new Date(dateString);
+        return date.toLocaleString();
+    };
+
+    // 뉴스 내용 요약 (500자로 제한)
+    const getSummaryContent = (content) => {
+        if (!content) return '';
+        
+        // HTML 태그 제거 및 요약
+        const textOnly = content.replace(/<[^>]*>/g, '');
+        if (textOnly.length > 500) {
+            return textOnly.substring(0, 500) + '...';
+        }
+        return textOnly;
     };
 
     return (
-        <S.Container>
+        <S.Container className={getContainerClass()}>
             <S.ContentWrapper>
                 <S.Title>킥온과 선수 이적 예측을 해보세요!</S.Title>
                 <S.Divider />
@@ -70,8 +151,85 @@ const Transferability = () => {
                     )}
                 </S.InputBox>
 
-                {isLoading ? (
-                    <S.Spinner />
+                {selectedNews ? (
+                    <S.NewsDetailContainer>
+                        <S.ActionButton isNavigation onClick={handleBackToNewsList}>
+                            <S.ButtonText>뉴스 목록으로</S.ButtonText>
+                        </S.ActionButton>
+
+                        {predictionDone && !showResult && (
+                            <S.PredictionNotice onClick={handleShowResult}>
+                                <S.BallIcon src={ballIcon} alt="축구공" />
+                                <span style={{ marginLeft: '6px' }}>예측이 완료되었습니다! 결과 확인하기</span>
+                                <S.ArrowIcon>→</S.ArrowIcon>
+                            </S.PredictionNotice>
+                        )}
+                        
+                        {selectedNews.thumbnailUrl && (
+                            <S.NewsDetailImage src={selectedNews.thumbnailUrl} alt="뉴스 이미지" />
+                        )}
+                        
+                        {selectedNews.category && (
+                            <div style={{padding: '0 1.3rem', marginTop: '2.37rem', display: 'flex', alignItems: 'center'}}>
+                                <img 
+                                    src={selectedNews.team?.logoUrl || defaultTeamLogo} 
+                                    alt={selectedNews.team?.nameKr || "팀 로고"} 
+                                    style={{
+                                        width: '0.6rem',
+                                        height: 'auto',
+                                        marginRight: '0.5rem'
+                                    }} 
+                                />
+                                <S.NewsDetailBadge>{selectedNews.category}</S.NewsDetailBadge>
+                            </div>
+                        )}
+                        
+                        <S.NewsDetailHeader>
+                            <S.NewsDetailTitle>{selectedNews.title}</S.NewsDetailTitle>
+                            <S.NewsDetailAuthor>
+                                <img
+                                    src={selectedNews.user?.profileImageUrl || defaultProfileImage}
+                                    alt="프로필"
+                                    width={24}
+                                    height={24}
+                                    style={{borderRadius: '50%'}}
+                                />
+                                {selectedNews.user?.nickname}
+                                <FaCheckCircle />
+                                <span>{formatDate(selectedNews.createdAt)}</span>
+                                <span>|</span>
+                                <span>읽음 {selectedNews.views}</span>
+                            </S.NewsDetailAuthor>
+                        </S.NewsDetailHeader>
+                        
+                        <S.NewsDetailContent 
+                            ref={newsContentRef} 
+                            dangerouslySetInnerHTML={{ 
+                                __html: selectedNews.content 
+                            }} 
+                        />
+                    </S.NewsDetailContainer>
+                ) : isLoading ? (
+                    <S.LoadingContainer>
+                        <S.SpinnerContainer>
+                            <S.Spinner />
+                        </S.SpinnerContainer>
+                        <S.NewsSection>
+                            <S.NewsTitle>예측이 진행되는 동안 뉴스를 확인해보세요!</S.NewsTitle>
+                            <NewsList type="other" onNewsClick={handleNewsClick} isCompact={true} />
+                        </S.NewsSection>
+                    </S.LoadingContainer>
+                ) : predictionDone && !showResult ? (
+                    <S.LoadingContainer>
+                        <S.NewsSection>
+                            <S.NewsTitle>예측이 완료되었습니다!</S.NewsTitle>
+                            <S.ActionButton onClick={handleShowResult}>
+                                <S.BallIcon src={ballIcon} alt="축구공" />
+                                <S.ButtonText>결과 확인하기</S.ButtonText>
+                            </S.ActionButton>
+                            <NewsList type="other" onNewsClick={handleNewsClick} isCompact={true} />
+                        </S.NewsSection>
+                    </S.LoadingContainer>
                 ) : hasError ? (
                     <NoData onRetry={handlePredict} />
                 ) : !transferResult ? (
@@ -88,7 +246,11 @@ const Transferability = () => {
                 )}
             </S.ContentWrapper>
 
-            <S.PredictButton onClick={handlePredict} disabled={isLoading}>
+            <S.PredictButton 
+                onClick={handlePredict} 
+                disabled={isLoading || (predictionDone && !showResult)} 
+                isLoading={isLoading}
+            >
                 <S.BallIcon src={ballIcon} alt="축구공" />
                 <S.ButtonText>갈까? 말까?</S.ButtonText>
             </S.PredictButton>

--- a/src/pages/Transferability/transferability.style.js
+++ b/src/pages/Transferability/transferability.style.js
@@ -5,6 +5,8 @@ export const ContentWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  flex: 1;
+  overflow: visible;
 `;
 
 export const Container = styled.div`
@@ -19,6 +21,18 @@ export const Container = styled.div`
     align-items: center;
     padding: 1.35rem 1rem;
     box-sizing: border-box;
+    transition: height 0.3s ease-in-out;
+    
+    &.expanded {
+      height: auto;
+      min-height: 37rem;
+      max-height: none;
+    }
+
+    &.loading {
+      height: auto;
+      padding-bottom: 1rem;
+    }
 `;
 
 export const Title = styled.div`
@@ -90,15 +104,33 @@ export const PredictButton = styled.button`
     gap: 0.45rem;
     flex-shrink: 0;
     border-radius: 0.36rem;
-    background: rgba(192, 12, 11, 0.90);
+    background: ${props => props.disabled ? 'rgba(192, 12, 11, 0.5)' : 'rgba(192, 12, 11, 0.90)'};
     box-shadow: 0px 2px 10px 0px rgba(217, 25, 32, 0.20);
     border: none;
-    cursor: pointer;
+    cursor: ${props => props.disabled ? 'not-allowed' : 'pointer'};
+    margin-top: ${props => props.isLoading ? '1.5rem' : '0'};
+    transition: background 0.3s ease;
+    
+    &:hover {
+        background: ${props => props.disabled ? 'rgba(192, 12, 11, 0.5)' : 'rgba(192, 12, 11, 1)'};
+    }
+    
+    /* 버튼이 비활성화되면 내부의 모든 요소에 투명도 적용 */
+    ${props => props.disabled && `
+        img, span {
+            opacity: 0.7;
+        }
+    `}
 `;
 
 export const BallIcon = styled.img`
     width: 0.8rem;
     height: 0.8rem;
+    transition: opacity 0.3s ease;
+`;
+
+export const BallIconWithMargin = styled(BallIcon)`
+  margin-right: 0.8rem;
 `;
 
 export const ButtonText = styled.span`
@@ -127,6 +159,13 @@ export const ResultMessage = styled.div`
   margin-bottom: 3rem;
 `;
 
+export const SpinnerContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 6rem;
+`;
 
 export const Spinner = styled.div`
   border: 4px solid #f3f3f3;
@@ -135,10 +174,174 @@ export const Spinner = styled.div`
   width: 48px;
   height: 48px;
   animation: spin 1s linear infinite;
-  margin: 40px auto;
 
   @keyframes spin {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
   }
+`;
+
+export const LoadingContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-height: none;
+  overflow-y: visible;
+`;
+
+export const NewsSection = styled.div`
+  margin-top: 0.5rem;
+  padding: 0 0.5rem;
+  width: 100%;
+  overflow: visible;
+`;
+
+export const NewsTitle = styled.h3`
+  font-size: 1rem;
+  font-weight: 600;
+  text-align: center;
+  margin-bottom: 1rem;
+  color: #333;
+`;
+
+export const ActionButton = styled.button`
+  display: flex;
+  width: ${props => props.isNavigation ? '8rem' : '12rem'};
+  height: ${props => props.isNavigation ? '1.4rem' : '1.7rem'};
+  padding: 0.1rem 0.54rem;
+  justify-content: center;
+  align-items: center;
+  gap: 0.45rem;
+  margin: ${props => props.isNavigation ? '1rem 0 1rem 1rem' : '1rem auto 1rem'};
+  border-radius: 0.36rem;
+  background: ${props => props.isNavigation ? '#6E6E6E' : props.disabled ? 'rgba(192, 12, 11, 0.5)' : 'rgba(192, 12, 11, 0.90)'};
+  color: #FFF;
+  font-size: ${props => props.isNavigation ? '0.6rem' : '0.65rem'};
+  font-weight: 400;
+  box-shadow: ${props => props.isNavigation ? '0px 1px 4px rgba(0, 0, 0, 0.1)' : '0px 2px 10px 0px rgba(217, 25, 32, 0.20)'};
+  border: none;
+  cursor: ${props => props.disabled ? 'not-allowed' : 'pointer'};
+  transition: all 0.2s ease-in-out;
+  
+  &:hover {
+    background: ${props => props.isNavigation ? '#5A5A5A' : props.disabled ? 'rgba(192, 12, 11, 0.5)' : 'rgba(192, 12, 11, 1)'};
+    transform: ${props => props.disabled ? 'none' : 'translateY(-1px)'};
+  }
+  
+  /* 버튼이 비활성화되면 내부의 모든 요소에 투명도 적용 */
+  ${props => props.disabled && `
+    img, span {
+      opacity: 0.7;
+    }
+  `}
+`;
+
+export const NewsDetailContainer = styled.div`
+  width: 100%;
+  max-height: none; 
+  overflow-y: visible;
+  padding: 0;
+  margin-bottom: 1rem;
+  border: 1px solid #DCDCDC;
+  border-radius: 0.625rem;
+  background: #FFF;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+`;
+
+export const NewsDetailHeader = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 1rem;
+  border-bottom: 0.0625rem solid #eee;
+`;
+
+export const NewsDetailBadge = styled.div`
+  display: flex;
+  height: 1.07rem;
+  padding: 0.125rem 0.625rem;
+  justify-content: center;
+  align-items: center;
+  gap: 0.625rem;
+  border-radius: 1.25rem;
+  background: #000;
+  color: #fff;
+  font-size: 0.53rem;
+  font-weight: 500;
+  margin-right: 0.5rem;
+  display: inline-block;
+`;
+
+export const NewsDetailAuthor = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.583rem;
+  color: #666;
+  margin-top: 0.75rem;
+`;
+
+export const NewsDetailTitle = styled.h1`
+  font-size: 1.25rem;
+  font-weight: bold;
+  margin: 0 0 0.75rem 0;
+  color: black;
+`;
+
+export const NewsDetailImage = styled.img`
+  width: 100%;
+  height: 10rem;
+  object-fit: cover;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  align-self: stretch;
+`;
+
+export const NewsDetailContent = styled.div`
+  margin: 0.7rem;
+  margin-bottom: 1rem;
+  font-size: 0.718rem;
+  line-height: 1.6;
+  color: #333;
+  max-height: none; // 15rem에서 none으로 변경
+  overflow-y: visible; // auto에서 visible로 변경
+  
+  img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+    margin: 0.7rem auto;
+    border-radius: 0.625rem;
+    object-fit: contain;
+  }
+  
+  p {
+    margin-bottom: 1rem;
+  }
+`;
+
+export const PredictionNotice = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 1rem;
+  margin: 0.5rem 1rem 1rem 1rem;
+  background: rgba(192, 12, 11, 0.1);
+  border-left: 3px solid rgba(192, 12, 11, 0.9);
+  border-radius: 0.25rem;
+  color: rgba(192, 12, 11, 0.9);
+  font-size: 0.7rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  
+  &:hover {
+    background: rgba(192, 12, 11, 0.15);
+    transform: translateY(-1px);
+  }
+`;
+
+export const ArrowIcon = styled.span`
+  margin-left: 0.5rem;
+  font-weight: bold;
 `;


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #131 

## ✨ 작업 개요
- 이적 예측 기능 사용 시 예측이 로딩되는 동안 사용자 경험을 개선하기 위해 관련 뉴스를 볼 수 있도록 기능을 추가 완료
- 예측 결과를 기다리는 동안 사용자는 뉴스 목록을 확인하고 상세 내용을 볼 수 있어 대기 시간을 유용하게 활용 가능

## 📷 이미지 첨부
- 예측 진행중
![예측 진행중](https://github.com/user-attachments/assets/51cde760-a6f5-4afd-9aaa-804d63102f0e)

- 예측 완료 (뉴스 목록)
![예측 완료 (목록)](https://github.com/user-attachments/assets/72f24a20-fce5-4200-bdb7-429c632211c5)

- 예측 완료 (뉴스 상세보기) 
![예측 완료 (상세보기)](https://github.com/user-attachments/assets/3672ec4f-7bb9-4807-93a9-d0a3cab41210)

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
