### PR TITLE
Feat: 중고상품 상태 변경 API 연동

### DIFF
--- a/src/apis/domains/market/usedProduct.js
+++ b/src/apis/domains/market/usedProduct.js
@@ -1,0 +1,8 @@
+import axiosInstance from '../../axios-instance';
+
+export const updateUsedProductStatus = async (usedProductPk, status) => {
+  const response = await axiosInstance.patch(`/api/usedProduct/${usedProductPk}/status`, {
+    status
+  });
+  return response.data;
+}; 

--- a/src/pages/Market/market.jsx
+++ b/src/pages/Market/market.jsx
@@ -31,6 +31,16 @@ const Market = () => {
 
     const formatPrice = (price) => `${price.toLocaleString()}원`;
 
+    const getStatusText = (status) => {
+        switch(status) {
+            case 'SOLD':
+                return '거래완료';
+            case 'RESERVED':
+                return '예약중';
+            default:
+                return '판매중';
+        }
+    };
 
     const handleMarketplaceClick = (itemId) => {
         navigate(`/market/${itemId}`);
@@ -56,8 +66,12 @@ const Market = () => {
                     <M.MarketplaceItem key={item.pk} onClick={() => handleMarketplaceClick(item.pk)}>
                         <M.MarketplaceImage>
                             <img src={item.profileImageUrl} alt={item.productName} />
-                            {item.usedProductStatus === 'SOLD' && <M.StatusBadge status="sold">판매완료</M.StatusBadge>}
-                            {item.usedProductStatus === 'RESERVED' && <M.StatusBadge status="reserved">예약 중</M.StatusBadge>}
+                            {item.usedProductStatus === 'SOLD' && (
+                                <M.StatusBadge status="sold">거래완료</M.StatusBadge>
+                            )}
+                            {item.usedProductStatus === 'RESERVED' && (
+                                <M.StatusBadge status="reserved">예약중</M.StatusBadge>
+                            )}
                         </M.MarketplaceImage>
                         <M.MarketplaceContent>
                             <M.MarketplaceTitle>{item.productName}</M.MarketplaceTitle>

--- a/src/pages/Market/market.jsx
+++ b/src/pages/Market/market.jsx
@@ -18,16 +18,35 @@ const Market = () => {
 
     const { selectedTeam } = useLeagueTeamStore();
 
-    const tabs = ["전체", selectedTeam?.nameKr || ""].filter(Boolean);
+    const tabs = ["전체", "판매 내역", selectedTeam?.nameKr || ""].filter(Boolean);
 
     useEffect(() => {
         const fetchItems = async () => {
             const res = await getItemList({ size: itemsPerPage, page: activePage });
-            setMarketplaceItems(res.items || []);
-            setTotalPages(res.totalPages || 1);
+            let filteredItems = res.items || [];
+            
+            // 판매 내역 탭이 선택된 경우 isMine이 true인 아이템만 필터링
+            if (activeTab === "판매 내역") {
+                filteredItems = filteredItems.filter(item => item.isMine);
+            }
+            // 팀 탭이 선택된 경우 해당 팀의 아이템만 필터링
+            else if (activeTab === selectedTeam?.nameKr) {
+                filteredItems = filteredItems.filter(item => item.teamPk === selectedTeam.pk);
+            }
+            
+            setMarketplaceItems(filteredItems);
+            
+            // 필터링된 결과의 페이지 수 계산
+            const filteredTotalPages = Math.ceil(filteredItems.length / itemsPerPage);
+            setTotalPages(filteredTotalPages || 1);
+            
+            // 현재 페이지가 필터링된 결과의 페이지 수보다 크면 첫 페이지로 이동
+            if (activePage > filteredTotalPages) {
+                setActivePage(1);
+            }
         };
         fetchItems();
-    }, [activePage]);
+    }, [activePage, activeTab, selectedTeam]);
 
     const formatPrice = (price) => `${price.toLocaleString()}원`;
 

--- a/src/pages/Market/marketDetail.jsx
+++ b/src/pages/Market/marketDetail.jsx
@@ -5,18 +5,20 @@ import NoData from "../../components/NoData/noData.jsx";
 import { useParams } from "react-router-dom";
 import { getItemDetail } from "../../apis/domains/market/getItemDetail.js";
 import { Phone } from "lucide-react";
+import { updateUsedProductStatus } from '../../apis/domains/market/usedProduct';
 
 const MarketDetail = () => {
     const { pk } = useParams();
     const [data, setData] = useState(null);
     const [error, setError] = useState(null);
 
+    const fetchDetail = async () => {
+        const res = await getItemDetail(pk);
+        setData(res.data);
+        setError(res.error);
+    };
+
     useEffect(() => {
-        const fetchDetail = async () => {
-            const res = await getItemDetail(pk);
-            setData(res.data);
-            setError(res.error);
-        };
         fetchDetail();
     }, [pk]);
 
@@ -25,6 +27,27 @@ const MarketDetail = () => {
             navigator.clipboard.writeText(data.phoneNumber)
                 .then(() => alert("전화번호가 복사되었습니다!"))
                 .catch(() => alert("복사에 실패했습니다."));
+        }
+    };
+
+    const handleStatusChange = async (newStatus) => {
+        try {
+            await updateUsedProductStatus(pk, newStatus);
+            await fetchDetail();
+            alert('상태가 변경되었습니다.');
+        } catch (error) {
+            alert('상태 변경에 실패했습니다.');
+        }
+    };
+
+    const getStatusText = (status) => {
+        switch(status) {
+            case 'SOLD':
+                return '거래완료';
+            case 'RESERVED':
+                return '예약중';
+            default:
+                return '판매중';
         }
     };
 
@@ -44,9 +67,23 @@ const MarketDetail = () => {
 
             <S.ArticleLabel>
                 <S.ArticleCategory>{data.category}</S.ArticleCategory>
-                <S.ArticleStatus status={data.usedProductStatus}>
-                    {data.usedProductStatus === "SOLD" ? "판매완료" : "판매중"}
-                </S.ArticleStatus>
+                {data.isMine ? (
+                    <S.StatusControl>
+                        <select 
+                            value={data.usedProductStatus}
+                            onChange={(e) => handleStatusChange(e.target.value)}
+                            className="status-select"
+                        >
+                            <option value="SALE"> 판매중</option>
+                            <option value="RESERVED"> 예약중</option>
+                            <option value="SOLD">거래완료</option>
+                        </select>
+                    </S.StatusControl>
+                ) : (
+                    <S.ArticleStatus status={data.usedProductStatus}>
+                        {getStatusText(data.usedProductStatus)}
+                    </S.ArticleStatus>
+                )}
             </S.ArticleLabel>
 
             <S.ArticleHeader>

--- a/src/pages/Market/marketDetail.style.js
+++ b/src/pages/Market/marketDetail.style.js
@@ -41,6 +41,29 @@ export const ArticleStatus = styled.span`
     status === "SOLD" ? "#8f8f8f" : "#c00c0b"};
 `;
 
+export const StatusControl = styled.div`
+  .status-select {
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 14px;
+    font-weight: 500;
+    border: 1px solid #E0E0E0;
+    background-color: white;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    
+    &:hover {
+      border-color: #1976D2;
+    }
+    
+    &:focus {
+      outline: none;
+      border-color: #1976D2;
+      box-shadow: 0 0 0 2px rgba(25, 118, 210, 0.1);
+    }
+  }
+`;
+
 export const ArticleHeader = styled.div`
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #147 

## ✨ 작업 개요
> 중고거래 상품의 상태 변경 기능과 판매 내역 조회 기능을 구현했습니다.

### 주요 변경사항
1. 중고상품 상태 변경 API 연동
   - PATCH /api/usedProduct/{usedProductPk}/status 엔드포인트 연동
   - 상태값에 따른 요청 바디 구성 (SALE, RESERVED, SOLD)
   - 상태 변경 후 UI 즉시 반영

2. 판매 내역 탭 추가
   - 중고거래 페이지에 '판매 내역' 탭 추가
   - isMine 필드를 활용하여 판매자 본인의 상품만 필터링
   - 필터링된 결과에 맞는 페이지네이션 로직 구현

## 📷 이미지 첨부
- 상태 변경
![상태 변경](https://github.com/user-attachments/assets/31695f10-74eb-4cc5-8e99-b31835898098)

- 상태 변경 완료
![상태 변경 완료](https://github.com/user-attachments/assets/ab39f067-fba5-411e-b950-8e5f40e42605)

- 판매 내역
![판매 내역](https://github.com/user-attachments/assets/71f68a67-4b95-4c33-9bc6-eff9bc0bd0a6)

## 🧐 집중 리뷰 요청

