### PR TITLE
Fix: 판매 내역 탭 수정 후 전체 탭 페이지네이션 오류 수정

### DIFF
--- a/src/apis/domains/market/getItemList.js
+++ b/src/apis/domains/market/getItemList.js
@@ -1,15 +1,18 @@
 import axiosInstance from "../../axios-instance.js";
 
-export const getItemList = async ({ size = 6, page = 1 }) => {
+export const getItemList = async ({ size = 6, page = 1, team }) => {
     try {
-        const response = await axiosInstance.get('/api/usedProduct', {
-            params: { size, page },
-        });
+        const params = {
+            size,
+            page,
+            ...(team !== undefined && { team })
+        };
+
+        const response = await axiosInstance.get('/api/usedProduct', { params });
 
         if (response?.code === 'GET_SUCCESS') {
-            console.log('API 응답:', response);
             return {
-                items: response.data, // 실제 상품 리스트
+                items: response.data,
                 totalPages: response.meta?.totalPages || 1,
             };
         } else {

--- a/src/components/EmptyState/emptyState.jsx
+++ b/src/components/EmptyState/emptyState.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+import xCard from "../../assets/xCard.svg";
+import * as S from "./emptyState.style";
+
+const EmptyState = ({ message, subMessage, buttonText, onRetry }) => (
+    <S.Container>
+        <S.Image src={xCard} alt="Empty state" />
+        <S.Message>{message}</S.Message>
+        {subMessage && <S.SubMessage>{subMessage}</S.SubMessage>}
+        <S.RetryButton onClick={onRetry}>
+            <S.RetryText>{buttonText}</S.RetryText>
+        </S.RetryButton>
+    </S.Container>
+);
+
+export default EmptyState; 

--- a/src/components/EmptyState/emptyState.style.js
+++ b/src/components/EmptyState/emptyState.style.js
@@ -1,0 +1,55 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  width: 100%;
+  padding: 1.5rem;
+`;
+
+export const Image = styled.img`
+  height: 5rem;
+  margin-bottom: 1.3rem;
+`;
+
+export const Message = styled.p`
+  color: #000;
+  text-align: center;
+  font-size: 0.9rem;
+  font-style: normal;
+  font-weight: 500;
+  margin-bottom: 1.2rem;
+`;
+
+export const SubMessage = styled.p`
+  color: #888;
+  text-align: center;
+  font-size: 0.8rem;
+  font-style: normal;
+  font-weight: 400;
+  margin-bottom: 1.2rem;
+`;
+
+export const RetryButton = styled.button`
+  display: flex;
+  height: 1.9rem;
+  padding: 0.5rem 1rem;
+  justify-content: center;
+  align-items: center;
+  gap: 0.375rem;
+  border-radius: 1rem;
+  background: #000;
+  box-shadow: 0 2px 10px 0 rgba(0, 0, 0, 0.2);
+  border: none;
+  cursor: pointer;
+`;
+
+export const RetryText = styled.span`
+  color: #fff;
+  font-size: 0.7rem;
+  font-style: normal;
+  font-weight: 400;
+`; 

--- a/src/pages/Market/market.jsx
+++ b/src/pages/Market/market.jsx
@@ -7,6 +7,7 @@ import { useLeagueTeamStore } from "../../store/useLeagueTeamStore.js";
 import { getItemList } from "../../apis/domains/market/getItemList.js";
 import { useNavigate } from "react-router-dom";
 import { formatDate } from "../../utils/formatDate.js";
+import EmptyState from "../../components/EmptyState/emptyState.jsx";
 
 const Market = () => {
     const [marketplaceItems, setMarketplaceItems] = useState([]);
@@ -15,6 +16,7 @@ const Market = () => {
     const itemsPerPage = 6;
     const [activeTab, setActiveTab] = useState("전체");
     const navigate = useNavigate();
+    const [myItems, setMyItems] = useState([]);
 
     const { selectedTeam } = useLeagueTeamStore();
 
@@ -22,31 +24,31 @@ const Market = () => {
 
     useEffect(() => {
         const fetchItems = async () => {
-            const res = await getItemList({ size: itemsPerPage, page: activePage });
-            let filteredItems = res.items || [];
-            
-            // 판매 내역 탭이 선택된 경우 isMine이 true인 아이템만 필터링
             if (activeTab === "판매 내역") {
-                filteredItems = filteredItems.filter(item => item.isMine);
-            }
-            // 팀 탭이 선택된 경우 해당 팀의 아이템만 필터링
-            else if (activeTab === selectedTeam?.nameKr) {
-                filteredItems = filteredItems.filter(item => item.teamPk === selectedTeam.pk);
-            }
-            
-            setMarketplaceItems(filteredItems);
-            
-            // 필터링된 결과의 페이지 수 계산
-            const filteredTotalPages = Math.ceil(filteredItems.length / itemsPerPage);
-            setTotalPages(filteredTotalPages || 1);
-            
-            // 현재 페이지가 필터링된 결과의 페이지 수보다 크면 첫 페이지로 이동
-            if (activePage > filteredTotalPages) {
-                setActivePage(1);
+                const res = await getItemList({ size: 100, page: 1 });
+                const mine = (res.items || []).filter(item => item.isMine);
+                setMyItems(mine);
+                setTotalPages(Math.max(1, Math.ceil(mine.length / itemsPerPage)));
+                setMarketplaceItems(mine.slice((activePage - 1) * itemsPerPage, activePage * itemsPerPage));
+            } else {
+                const params = {
+                    size: itemsPerPage,
+                    page: activePage,
+                    team: activeTab === selectedTeam?.nameKr ? selectedTeam.pk : undefined
+                };
+                const res = await getItemList(params);
+                setMarketplaceItems(res.items || []);
+                setTotalPages(res.totalPages || 1);
             }
         };
         fetchItems();
-    }, [activePage, activeTab, selectedTeam]);
+    }, [activeTab, activePage, selectedTeam]);
+
+    useEffect(() => {
+        if (activeTab === "판매 내역") {
+            setMarketplaceItems(myItems.slice((activePage - 1) * itemsPerPage, activePage * itemsPerPage));
+        }
+    }, [activePage, myItems, activeTab]);
 
     const formatPrice = (price) => `${price.toLocaleString()}원`;
 
@@ -80,34 +82,43 @@ const Market = () => {
                     </M.Tab>
                 ))}
             </M.TabContainer>
-            <M.MarketplaceGrid>
-                {marketplaceItems.map((item) => (
-                    <M.MarketplaceItem key={item.pk} onClick={() => handleMarketplaceClick(item.pk)}>
-                        <M.MarketplaceImage>
-                            <img src={item.profileImageUrl} alt={item.productName} />
-                            {item.usedProductStatus === 'SOLD' && (
-                                <M.StatusBadge status="sold">거래완료</M.StatusBadge>
-                            )}
-                            {item.usedProductStatus === 'RESERVED' && (
-                                <M.StatusBadge status="reserved">예약중</M.StatusBadge>
-                            )}
-                        </M.MarketplaceImage>
-                        <M.MarketplaceContent>
-                            <M.MarketplaceTitle>{item.productName}</M.MarketplaceTitle>
-                            <M.MarketplacePrice>{formatPrice(item.price)}</M.MarketplacePrice>
-                            <M.MarketplaceInfo>
-                                <M.MarketplaceAuthor>
-                                    <img src={item.user?.profileImageUrl} alt="프로필" />
-                                    {item.user?.nickname}
-                                </M.MarketplaceAuthor>
-                                <M.MarketplaceStats>
-                                    <span>{formatDate(item.createdAt)}</span>
-                                </M.MarketplaceStats>
-                            </M.MarketplaceInfo>
-                        </M.MarketplaceContent>
-                    </M.MarketplaceItem>
-                ))}
-            </M.MarketplaceGrid>
+            {activeTab === "판매 내역" && marketplaceItems.length === 0 ? (
+                <EmptyState
+                    message="판매 내역이 없습니다."
+                    subMessage="상품을 등록해보세요!"
+                    buttonText="상품 등록하기"
+                    onRetry={() => navigate("/market/write")}
+                />
+            ) : (
+                <M.MarketplaceGrid>
+                    {marketplaceItems.map((item) => (
+                        <M.MarketplaceItem key={item.pk} onClick={() => handleMarketplaceClick(item.pk)}>
+                            <M.MarketplaceImage>
+                                <img src={item.profileImageUrl} alt={item.productName} />
+                                {item.usedProductStatus === 'SOLD' && (
+                                    <M.StatusBadge status="sold">거래완료</M.StatusBadge>
+                                )}
+                                {item.usedProductStatus === 'RESERVED' && (
+                                    <M.StatusBadge status="reserved">예약중</M.StatusBadge>
+                                )}
+                            </M.MarketplaceImage>
+                            <M.MarketplaceContent>
+                                <M.MarketplaceTitle>{item.productName}</M.MarketplaceTitle>
+                                <M.MarketplacePrice>{formatPrice(item.price)}</M.MarketplacePrice>
+                                <M.MarketplaceInfo>
+                                    <M.MarketplaceAuthor>
+                                        <img src={item.user?.profileImageUrl} alt="프로필" />
+                                        {item.user?.nickname}
+                                    </M.MarketplaceAuthor>
+                                    <M.MarketplaceStats>
+                                        <span>{formatDate(item.createdAt)}</span>
+                                    </M.MarketplaceStats>
+                                </M.MarketplaceInfo>
+                            </M.MarketplaceContent>
+                        </M.MarketplaceItem>
+                    ))}
+                </M.MarketplaceGrid>
+            )}
 
             <PS.PaginationWrapper>
                 <PS.NavButton


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #154 

## ✨ 작업 개요
> 판매 내역 탭 수정 후 전체 탭에서 페이지네이션이 작동하지 않는 문제를 수정했습니다.  
> 또한, 판매 내역이 비어 있을 때 사용자에게 안내 메시지를 보여주고,  
> 상품 등록 페이지로 이동할 수 있는 버튼을 추가했습니다.

## 📷 이미지 첨부 (선택)
- 페이지네이션 정상 작동 화면 GIF 또는 스크린샷  
![image](https://github.com/user-attachments/assets/648d7365-c8d4-4185-9d24-4eb0e60d3809)

- 판매 내역 비어있을 때 나타나는 EmptyState UI 스크린샷
![image](https://github.com/user-attachments/assets/09484f29-5eb1-466b-8fa4-5af9ed4722d9)


## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
